### PR TITLE
fix: disable hooks in recovery mode to prevent boot loops

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -39,7 +39,7 @@ kernelsu-objs += infra/seccomp_cache.o
 kernelsu-objs += infra/su_mount_ns.o
 kernelsu-objs += infra/symbol_resolver.o
 
-ifneq ($(CONFIG_KSU_DISABLE_MANAGER),y)
+ifneq ($(strip $(CONFIG_KSU_DISABLE_MANAGER)),y)
 kernelsu-objs += manager/apk_sign.o
 kernelsu-objs += manager/pkg_observer.o
 kernelsu-objs += manager/throne_tracker.o
@@ -68,13 +68,13 @@ kernelsu-objs += feature/adb_root.o
 kernelsu-objs += feature/selinux_hide.o
 
 ifdef KBUILD_EXTMOD
-ifeq ($(CONFIG_KSU_DISABLE_MANAGER),y)
+ifeq ($(strip $(CONFIG_KSU_DISABLE_MANAGER)),y)
 ccflags-y += -DCONFIG_KSU_DISABLE_MANAGER=1
 endif
-ifeq ($(CONFIG_KSU_DISABLE_POLICY),y)
+ifeq ($(strip $(CONFIG_KSU_DISABLE_POLICY)),y)
 ccflags-y += -DCONFIG_KSU_DISABLE_POLICY=1
 endif
-ifeq ($(CONFIG_KSU_DEBUG),y)
+ifeq ($(strip $(CONFIG_KSU_DEBUG)),y)
 ccflags-y += -DCONFIG_KSU_DEBUG=1
 endif
 ifeq ($(CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER),y)

--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -1,21 +1,36 @@
 kernelsu-objs := core/init.o
-
 kernelsu-objs += feature/kernel_umount.o
 kernelsu-objs += feature/sulog.o
 kernelsu-objs += feature/sucompat.o
 
+# Architecture
+ifneq ($(filter y arm64 aarch64,$(CONFIG_ARM64) $(ARCH)),)
+KSU_ARCH := arm64
+else ifneq ($(filter y x86_64 i386,$(CONFIG_X86_64) $(ARCH)),)
+KSU_ARCH := x86_64
+endif
+
+# Core utilities ('selinux hide'/hooks)
+ifeq ($(strip $(CONFIG_KPROBES)),y)
 kernelsu-objs += hook/lsm_hook.o
-kernelsu-objs += hook/setuid_hook.o
+ifdef KSU_ARCH
+kernelsu-objs += hook/$(KSU_ARCH)/patch_memory.o
+endif
+endif
+
+# Hooks (excluded for SuSFS)
+ifneq ($(strip $(CONFIG_KSU_SUSFS)),y)
+ifeq ($(strip $(CONFIG_KPROBES)),y)
 kernelsu-objs += hook/syscall_event_bridge.o
 kernelsu-objs += hook/syscall_hook_manager.o
 kernelsu-objs += hook/tp_marker.o
-ifeq ($(CONFIG_ARM64),y)
-kernelsu-objs += hook/arm64/patch_memory.o
-kernelsu-objs += hook/arm64/syscall_hook.o
-else ifeq ($(CONFIG_X86_64),y)
-kernelsu-objs += hook/x86_64/patch_memory.o
-kernelsu-objs += hook/x86_64/syscall_hook.o
+ifdef KSU_ARCH
+kernelsu-objs += hook/$(KSU_ARCH)/syscall_hook.o
 endif
+endif
+endif
+
+kernelsu-objs += hook/setuid_hook.o
 kernelsu-objs += extras.o
 
 kernelsu-objs += infra/file_wrapper.o
@@ -149,5 +164,17 @@ ccflags-y += -DKSU_NEW_DCACHE_FLUSH=$(KSU_NEW_DCACHE_FLUSH)
 
 ccflags-y += -Wno-strict-prototypes -Wno-int-conversion -Wno-gcc-compat -Wno-missing-prototypes
 ccflags-y += -Wno-declaration-after-statement -Wno-unused-function -Wno-unused-variable
+
+## For susfs stuff ##
+ifeq ($(strip $(CONFIG_KSU_SUSFS)),y)
+ifeq ($(shell test -e $(srctree)/fs/susfs.c; echo $$?),0)
+$(eval SUSFS_VERSION=$(shell cat $(srctree)/include/linux/susfs.h | grep -E '^#define SUSFS_VERSION' | cut -d' ' -f3 | sed 's/"//g'))
+$(info )
+$(info -- SUSFS_VERSION: $(SUSFS_VERSION))
+else
+$(info -- You have not integrated susfs in your kernel yet.)
+$(info -- Read: https://gitlab.com/simonpunk/susfs4ksu)
+endif
+endif
 
 # Keep a new line here!! Because someone may append config

--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -106,8 +106,12 @@ KERNEL_GIT_ROOT := $(shell cd $(srctree) && $(LPATH) git rev-parse --show-toplev
 ifneq ($(GIT_ROOT),$(KERNEL_GIT_ROOT))
 # Only set version if it's a different repo from kernel
 $(shell cd $(GIT_ROOT) && [ -f .git/shallow ] && $(LPATH) git fetch --unshallow 2>/dev/null || true)
-KSU_GIT_VERSION := $(shell cd $(GIT_ROOT) && $(LPATH) git rev-list --count HEAD 2>/dev/null)
-KSU_GIT_TAG := $(shell cd $(GIT_ROOT) && $(LPATH) git describe --tags --abbrev=0 2>/dev/null)
+# Get the base branch name by stripping suffixes (e.g., dev-susfs -> dev)
+BASE_BRANCH := $(shell cd $(GIT_ROOT) && $(LPATH) git rev-parse --abbrev-ref HEAD | sed 's:-.*::' 2>/dev/null)
+# Find the merge-base with the official origin branch to exclude local commits
+BASE_COMMIT := $(shell cd $(GIT_ROOT) && $(LPATH) git merge-base HEAD refs/remotes/origin/$(BASE_BRANCH) 2>/dev/null || $(LPATH) git merge-base HEAD refs/remotes/origin/main 2>/dev/null || echo HEAD)
+KSU_GIT_VERSION := $(shell cd $(GIT_ROOT) && $(LPATH) git rev-list --count $(BASE_COMMIT) 2>/dev/null)
+KSU_GIT_TAG := $(shell cd $(GIT_ROOT) && $(LPATH) git describe --tags --abbrev=0 $(BASE_COMMIT) 2>/dev/null)
 KSU_GIT_VERSION_VALID := 1
 $(info -- KernelSU-Next Git repo detected at: $(GIT_ROOT))
 endif

--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -141,12 +141,9 @@ endif
 KSU_NEW_DCACHE_FLUSH := $(shell grep -q __flush_dcache_area $(srctree)/arch/arm64/include/asm/cacheflush.h ; echo $$?)
 $(info -- KernelSU-Next new DCACHE flush: $(KSU_NEW_DCACHE_FLUSH))
 
-ifndef KSU_NEXT_MANAGER_SIZE
-KSU_NEXT_MANAGER_SIZE := 0x3e6
-endif
-
-ifndef KSU_NEXT_MANAGER_HASH
-KSU_NEXT_MANAGER_HASH := 79e590113c4c4c0c222978e413a5faa801666957b1212a328e46c00c69821bf7
+ifndef KSU_NEXT_MANAGER_LIST
+# KSUN, pershoot
+KSU_NEXT_MANAGER_LIST := 0x3e6:79e590113c4c4c0c222978e413a5faa801666957b1212a328e46c00c69821bf7,0x338:f26471a28031130362bce7eebffb9a0b8afc3095f163ce0c75a309f03b644a1f
 endif
 
 ifdef KSU_MANAGER_PACKAGE
@@ -154,11 +151,8 @@ ccflags-y += -DKSU_MANAGER_PACKAGE=\"$(KSU_MANAGER_PACKAGE)\"
 $(info -- KernelSU-Next Manager package name: $(KSU_MANAGER_PACKAGE))
 endif
 
-$(info -- KernelSU-Next Manager signature size: $(KSU_NEXT_MANAGER_SIZE))
-$(info -- KernelSU-Next Manager signature hash: $(KSU_NEXT_MANAGER_HASH))
-
-ccflags-y += -DEXPECTED_MANAGER_SIZE=$(KSU_NEXT_MANAGER_SIZE)
-ccflags-y += -DEXPECTED_MANAGER_HASH=\"$(KSU_NEXT_MANAGER_HASH)\"
+$(info -- KernelSU-Next Manager signatures: $(KSU_NEXT_MANAGER_LIST))
+ccflags-y += -DKSU_NEXT_MANAGER_LIST=\"$(KSU_NEXT_MANAGER_LIST)\"
 
 ccflags-y += -DKSU_NEW_DCACHE_FLUSH=$(KSU_NEW_DCACHE_FLUSH)
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -18,6 +18,16 @@ config KSU_DEBUG
 	help
 	  Enable KernelSU debug mode.
 
+config KSU_THRONE_TRACKER_ALWAYS_THREADED
+	bool "Always run throne tracker in a kthread"
+	depends on KSU
+	default y
+	help
+	  Runs throne_tracker in a separate kthread, including the first run.
+	  Significantly decreases boot time, but may delay crowning slightly
+	  on some FDE / FBEv1 setups.
+	  If unsure, say n.
+
 config KSU_DISABLE_MANAGER
 	bool "Disable KernelSU manager integration"
 	depends on KSU

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -2,12 +2,12 @@ menu "KernelSU"
 
 config KSU
 	tristate "KernelSU function support"
-	depends on KPROBES && EXT4_FS
+	depends on KPROBES || SUSFS
 	default y
 	help
 	  Enable kernel-level root privileges on Android System.
-	  Requires CONFIG_KPROBES for kernel hooking support.
-	  Requires CONFIG_EXT4_FS for `ext4_unregister_sysfs`.
+	  Requires CONFIG_KPROBES for kernel hooking support (if SuSFS is not used).
+	  Optional CONFIG_EXT4_FS for `ext4_unregister_sysfs` (redundant with SuSFS).
 	  To compile as a module, choose M here: the
 	  module will be called kernelsu.
 
@@ -42,5 +42,96 @@ config KSU_X86_PATCH_SYSCALL_DISPATCHER
 	help
 	  Dynamically patch x64's hardened syscall dispatcher to support syscall hooks. This is a
 	  replacement for a kernel source code patch, and is useful for x86_64 LKM mode.
+
+menu "KernelSU - SUSFS"
+config KSU_SUSFS
+	bool "KernelSU addon - SUSFS"
+	depends on KSU
+	depends on THREAD_INFO_IN_TASK
+	default y
+	help
+	  Patch and Enable SUSFS to kernel with KernelSU.
+
+config KSU_SUSFS_SUS_PATH
+	bool "Enable to hide suspicious path"
+	depends on KSU_SUSFS
+	default y
+	help
+	  - Allow hiding the user-defined path and all its sub-paths from various system calls.
+	  - Use "add_sus_path_loop" instead of "add_sus_path" if the user-defined path is frequently modified.
+	  - Use with cautious as it may cause performance loss and will be vulnerable to side channel attacks,
+		just disable this feature if it doesn't work for you or you don't need it at all.
+	  - Effective only on zygote spawned user app process with uid >= 10000.
+
+config KSU_SUSFS_SUS_MOUNT
+	bool "Enable to hide suspicious mounts"
+	depends on KSU_SUSFS
+	default y
+	help
+	  - Automatically assign fake mnt_id and fake mnt_group_id for mounts mounted by ksu process until /sdcard is  decrypted, this is to evade from mnt_id/mnt_group_id gap detections.
+	  - Allow hiding all sus mounts from /proc/self/[mounts|mountinfo|mountstat] for non-su processes.
+
+config KSU_SUSFS_SUS_KSTAT
+	bool "Enable to spoof suspicious kstat"
+	depends on KSU_SUSFS
+	default y
+	help
+	  - Allow spoofing the kstat of user-defined file/directory.
+	  - Effective only on zygote spawned user app process with uid >= 10000.
+
+config KSU_SUSFS_SPOOF_UNAME
+	bool "Enable to spoof uname"
+	depends on KSU_SUSFS
+	default y
+	help
+	  - Allow spoofing the string returned by uname syscall to user-defined string.
+	  - Effective on all processes.
+
+config KSU_SUSFS_ENABLE_LOG
+	bool "Enable logging susfs log to kernel"
+	depends on KSU_SUSFS
+	default y
+	help
+	  - Allow logging susfs log to kernel, uncheck it to completely disable all susfs log.
+
+config KSU_SUSFS_HIDE_KSU_SUSFS_SYMBOLS
+	bool "Enable to automatically hide ksu and susfs symbols from /proc/kallsyms"
+	depends on KSU_SUSFS
+	default y
+	help
+	  - Automatically hide ksu and susfs symbols from '/proc/kallsyms'.
+	  - Effective on all processes.
+
+config KSU_SUSFS_SPOOF_CMDLINE_OR_BOOTCONFIG
+	bool "Enable to spoof /proc/bootconfig (gki) or /proc/cmdline (non-gki)"
+	depends on KSU_SUSFS
+	default y
+	help
+	  - Spoof the output of /proc/bootconfig (gki) or /proc/cmdline (non-gki) with a user-defined file.
+	  - Effective on all processes.
+
+config KSU_SUSFS_OPEN_REDIRECT
+	bool "Enable to redirect a path to be opened with another path"
+	depends on KSU_SUSFS
+	default y
+	help
+	  - Allow redirecting a target path to be opened with another user-defined path.
+	  - Both target path and redirected path must be existed before they can be added to the kernel.
+	  - Users have to take care of the selinux permission of both target path and redirected path by themselves.
+	  - OPEN_REDIRECT does not bypass detections, but users may try other feature like SUS_KSTAT to bypass some of them.
+	  - Effective only on processes with pre-defined uid scheme.
+
+config KSU_SUSFS_SUS_MAP
+	bool "Enable to hide some mmapped real file from different proc maps interfaces"
+	depends on KSU_SUSFS
+	default y
+	help
+	  - Allow hiding mmapped real file from /proc/<pid>/[maps|smaps|smaps_rollup|map_files|mem|pagemap]
+	  - It does NOT support hiding for anon memory.
+	  - It does NOT hide any inline hooks or plt hooks cause by the injected library itself.
+	  - It may not be able to evade detections by apps that implement a good injection detection.
+	  - Effective only on zygote spawned umounted user app process >= 10000.
+
+endmenu
 
 endmenu

--- a/kernel/core/init.c
+++ b/kernel/core/init.c
@@ -26,6 +26,13 @@
 #include "feature/sulog.h"
 #include "infra/symbol_resolver.h"
 
+#ifdef CONFIG_KSU_SUSFS
+#include <linux/susfs.h>
+#include "hook/setuid_hook.h"
+#include "feature/sucompat.h"
+extern void ksu_avc_spoof_late_init(void);
+#endif
+
 #if defined(__x86_64__) && !defined(CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER)
 #include <asm/cpufeature.h>
 #include <linux/version.h>
@@ -86,6 +93,10 @@ module_param_named(norc, ksu_no_custom_rc, bool, 0);
 
 int __init kernelsu_init(void)
 {
+#ifdef CONFIG_KSU_SUSFS
+	susfs_init();
+#endif // #ifdef KSU_SUSFS
+
 #if defined(__x86_64__) && !defined(CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER)
     // If the kernel has the hardening patch, X86_FEATURE_INDIRECT_SAFE must be set
     if (!boot_cpu_has(X86_FEATURE_INDIRECT_SAFE)) {
@@ -128,19 +139,32 @@ int __init kernelsu_init(void)
 	}
 
 	ksu_init_symbol_resolver();
+
+#if !defined(CONFIG_KSU_SUSFS) && defined(CONFIG_KPROBES)
 	ksu_syscall_hook_init();
+#endif
 
 	ksu_feature_init();
 
 	ksu_sulog_init();
 
-	ksu_adb_root_init();
-
+#ifndef CONFIG_KSU_SUSFS
+#ifdef CONFIG_KPROBES
 	ksu_lsm_hook_init();
+#endif
+#endif
 
 	ksu_selinux_hide_init();
 
+	ksu_adb_root_init();
+
 	ksu_supercalls_init();
+
+#ifdef CONFIG_KSU_SUSFS
+	ksu_sucompat_init();
+	ksu_setuid_hook_init();
+	ksu_avc_spoof_init();
+#endif
 
 	if (ksu_late_loaded) {
 		pr_info("late load mode, skipping kprobe hooks\n");
@@ -157,7 +181,9 @@ int __init kernelsu_init(void)
 		ksu_allowlist_init();
 		ksu_load_allow_list();
 
+#if !defined(CONFIG_KSU_SUSFS) && defined(CONFIG_KPROBES)
 		ksu_syscall_hook_manager_init();
+#endif
 
 		ksu_throne_tracker_init();
 		ksu_observer_init();
@@ -166,13 +192,20 @@ int __init kernelsu_init(void)
 		ksu_boot_completed = true;
 		track_throne(false);
 
+		#ifdef CONFIG_KSU_SUSFS
+		ksu_avc_spoof_late_init();
+		#endif
+		ksu_selinux_hide_drop_backup_if_unused();
+
 		if (!getenforce()) {
 			pr_info("Permissive SELinux, enforcing\n");
 			setenforce(true);
 		}
 
 	} else {
+#if !defined(CONFIG_KSU_SUSFS) && defined(CONFIG_KPROBES)
 		ksu_syscall_hook_manager_init();
+#endif
 
 		ksu_allowlist_init();
 
@@ -194,7 +227,9 @@ int __init kernelsu_init(void)
 void __exit kernelsu_exit(void)
 {
 	// Phase 1: Stop all hooks first to prevent new callbacks
+#if !defined(CONFIG_KSU_SUSFS) && defined(CONFIG_KPROBES)
 	ksu_syscall_hook_manager_exit();
+#endif
 
 	ksu_supercalls_exit();
 
@@ -211,9 +246,19 @@ void __exit kernelsu_exit(void)
 
 	ksu_allowlist_exit();
 
+#ifdef CONFIG_KSU_SUSFS
+	ksu_avc_spoof_exit();
+	ksu_sucompat_exit();
+	ksu_setuid_hook_exit();
+#endif
+
 	ksu_selinux_hide_exit();
 
+#ifndef CONFIG_KSU_SUSFS
+#ifdef CONFIG_KPROBES
 	ksu_lsm_hook_exit();
+#endif
+#endif
 
 	ksu_adb_root_exit();
 

--- a/kernel/core/init.c
+++ b/kernel/core/init.c
@@ -28,9 +28,12 @@
 
 #ifdef CONFIG_KSU_SUSFS
 #include <linux/susfs.h>
+#include <linux/init.h>
 #include "hook/setuid_hook.h"
 #include "feature/sucompat.h"
 extern void ksu_avc_spoof_late_init(void);
+extern struct static_key_true ksu_is_init_rc_hook_enabled;
+extern struct static_key_true ksu_is_input_hook_enabled;
 #endif
 
 #if defined(__x86_64__) && !defined(CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER)
@@ -80,6 +83,7 @@ __attribute__((naked)) int __init kernelsu_init_early(void)
 
 struct cred *ksu_cred;
 bool ksu_late_loaded;
+bool ksu_is_recovery;
 
 #ifdef CONFIG_KSU_DEBUG
 bool allow_shell = true;
@@ -95,6 +99,26 @@ int __init kernelsu_init(void)
 {
 #ifdef CONFIG_KSU_SUSFS
 	susfs_init();
+
+	/* Detect recovery mode from kernel command line.
+	 * In recovery, KernelSU hooks can cause boot loops because the normal
+	 * Android boot sequence (init second_stage -> zygote -> post-fs-data)
+	 * never happens, leaving hooks permanently active.
+	 */
+	if (saved_command_line &&
+	    (strstr(saved_command_line, "androidboot.force_normal_boot=0") ||
+	     (!strstr(saved_command_line, "androidboot.force_normal_boot=1") &&
+	      (strstr(saved_command_line, "androidboot.mode=recovery") ||
+	       strstr(saved_command_line, "bootmode=recovery"))))) {
+		ksu_is_recovery = true;
+		pr_info("KernelSU: Recovery mode detected, disabling hooks to prevent boot loop\n");
+		/* Disable init.rc read/fstat interception */
+		if (static_key_enabled(&ksu_is_init_rc_hook_enabled))
+			static_branch_disable(&ksu_is_init_rc_hook_enabled);
+		/* Disable input event hook (safe mode detection) */
+		if (static_key_enabled(&ksu_is_input_hook_enabled))
+			static_branch_disable(&ksu_is_input_hook_enabled);
+	}
 #endif // #ifdef KSU_SUSFS
 
 #if defined(__x86_64__) && !defined(CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER)

--- a/kernel/extras.c
+++ b/kernel/extras.c
@@ -8,6 +8,12 @@
 #include "runtime/ksud.h"
 #include "infra/seccomp_cache.h"
 
+#include "linux/jump_label.h"
+
+#ifdef CONFIG_KSU_SUSFS
+extern struct static_key_false susfs_is_avc_log_spoofing_enabled;
+#endif
+
 // sorry for the ifdef hell
 // but im too lazy to fragment this out.
 // theres only one feature so far anyway
@@ -22,7 +28,7 @@ static atomic_t disable_spoof = ATOMIC_INIT(1);
 void ksu_avc_spoof_enable();
 void ksu_avc_spoof_disable();
 
-static bool ksu_avc_spoof_enabled = true;
+bool ksu_avc_spoof_enabled = true;
 static bool boot_completed = false;
 
 static int avc_spoof_feature_get(u64 *value)
@@ -34,6 +40,13 @@ static int avc_spoof_feature_get(u64 *value)
 static int avc_spoof_feature_set(u64 value)
 {
 	bool enable = value != 0;
+
+#ifdef CONFIG_KSU_SUSFS
+	if (enable && static_branch_unlikely(&susfs_is_avc_log_spoofing_enabled)) {
+		pr_info("avc_spoof: SuSFS spoof active, skipping ksu toggle\n");
+		return -EBUSY;
+	}
+#endif
 
 	if (enable == ksu_avc_spoof_enabled) {
 		pr_info("avc_spoof: no need to change\n");
@@ -85,6 +98,11 @@ int ksu_handle_slow_avc_audit(u32 *tsid)
 {
 	if (atomic_read(&disable_spoof))
 		return 0;
+
+#ifdef CONFIG_KSU_SUSFS
+	if (static_branch_unlikely(&susfs_is_avc_log_spoofing_enabled))
+		return 0;
+#endif
 
 	// if tsid is su, we just replace it
 	// unsure if its enough, but this is how it is aye?
@@ -162,6 +180,7 @@ static void destroy_kprobe(struct kprobe **kp_ptr)
 
 void ksu_avc_spoof_disable(void)
 {
+	ksu_avc_spoof_enabled = false;
 #ifdef CONFIG_KPROBES
 	pr_info("avc_spoof/exit: unregister slow_avc_audit kprobe!\n");
 	destroy_kprobe(&slow_avc_audit_kp);
@@ -172,6 +191,7 @@ void ksu_avc_spoof_disable(void)
 
 void ksu_avc_spoof_enable(void) 
 {
+	ksu_avc_spoof_enabled = true;
 	int ret = get_sid();
 	if (ret) {
 		pr_info("avc_spoof/init: sid grab fail!\n");

--- a/kernel/feature/adb_root.c
+++ b/kernel/feature/adb_root.c
@@ -9,9 +9,15 @@
 #include <linux/ptrace.h>
 #include <linux/static_key.h>
 #include <linux/slab.h>
+#include <linux/sched/task_stack.h>
+
+#ifdef CONFIG_KSU_SUSFS
+#include <linux/susfs_def.h>
+#endif
 
 #include "adb_root.h"
 #include "arch.h"
+#include "policy/app_profile.h"
 #include "policy/feature.h"
 #include "selinux/selinux.h"
 
@@ -19,6 +25,16 @@
 
 DEFINE_STATIC_KEY_FALSE(ksu_adb_root);
 
+#ifdef CONFIG_KSU_SUSFS
+static inline long is_exec_adbd(const char *filename)
+{
+    if (strstr(filename, "adbd"))
+        pr_info("is_exec_adbd() => filename: %s\n", filename);
+
+    return (susfs_starts_with(filename, "/apex/") &&
+                susfs_ends_with(filename, "/adbd"));
+}
+#else
 static long is_exec_adbd(struct pt_regs *regs)
 {
     static const char kAdbd[] = "/adbd";
@@ -44,8 +60,9 @@ static long is_exec_adbd(struct pt_regs *regs)
 
     return 1;
 }
+#endif
 
-static long is_libadbroot_ok()
+static long is_libadbroot_ok(void)
 {
     static const char kLibAdbRoot[] = "/data/adb/ksu/lib/libadbroot.so";
     struct path path;
@@ -65,15 +82,16 @@ static long is_libadbroot_ok()
     return ret;
 }
 
-static long setup_ld_preload(struct pt_regs *regs)
+#ifdef CONFIG_KSU_SUSFS
+static long setup_ld_preload(void ***envp_user_ptr)
 {
     static const char kLdPreload[] = "LD_PRELOAD=/data/adb/ksu/lib/libadbroot.so";
     static const char kLdLibraryPath[] = "LD_LIBRARY_PATH=/data/adb/ksu/lib";
     static const size_t kReadEnvBatch = 16;
     static const size_t kPtrSize = sizeof(unsigned long);
-    unsigned long stackp = user_stack_pointer(regs);
+    unsigned long stackp = current_user_stack_pointer();
     unsigned long envp, ld_preload_p, ld_library_path_p;
-    unsigned long *envp_p = (unsigned long *)&PT_REGS_PARM3(regs);
+    unsigned long *envp_p = (unsigned long)envp_user_ptr;
     unsigned long *tmp_env_p = NULL, *tmp_env_p2 = NULL;
     size_t env_count = 0, total_size;
     long ret;
@@ -81,14 +99,14 @@ static long setup_ld_preload(struct pt_regs *regs)
     envp = (char __user **)untagged_addr((unsigned long)*envp_p);
 
     ld_preload_p = stackp = ALIGN_DOWN(stackp - sizeof(kLdPreload), 8);
-    ret = copy_to_user(ld_preload_p, kLdPreload, sizeof(kLdPreload));
+    ret = copy_to_user((void __user *)ld_preload_p, kLdPreload, sizeof(kLdPreload));
     if (ret != 0) {
         pr_warn("write ld_preload when adb_root_handle_execve failed: %ld\n", ret);
         return -EFAULT;
     }
 
     ld_library_path_p = stackp = ALIGN_DOWN(stackp - sizeof(kLdLibraryPath), 8);
-    ret = copy_to_user(ld_library_path_p, kLdLibraryPath, sizeof(kLdLibraryPath));
+    ret = copy_to_user((void __user *)ld_library_path_p, kLdLibraryPath, sizeof(kLdLibraryPath));
     if (ret != 0) {
         pr_warn("write ld_library_path when adb_root_handle_execve failed: %ld\n", ret);
         return -EFAULT;
@@ -102,7 +120,7 @@ static long setup_ld_preload(struct pt_regs *regs)
             goto out_release_env_p;
         }
         tmp_env_p = tmp_env_p2;
-        ret = copy_from_user(&tmp_env_p[env_count], envp + env_count * kPtrSize, kReadEnvBatch * kPtrSize);
+        ret = copy_from_user(&tmp_env_p[env_count], (void __user *)(envp + env_count * kPtrSize), kReadEnvBatch * kPtrSize);
         if (ret < 0) {
             pr_warn("Access envp when adb_root_handle_execve failed: %ld\n", ret);
             ret = -EFAULT;
@@ -141,7 +159,7 @@ static long setup_ld_preload(struct pt_regs *regs)
     total_size = env_count * kPtrSize;
 
     stackp -= total_size;
-    ret = copy_to_user(stackp, tmp_env_p, total_size);
+    ret = copy_to_user((void __user *)stackp, tmp_env_p, total_size);
     if (ret != 0) {
         pr_err("copy new env failed: %ld\n", ret);
         ret = -EFAULT;
@@ -158,7 +176,128 @@ out_release_env_p:
 
     return ret;
 }
+#else
+static long setup_ld_preload(struct pt_regs *regs)
+{
+    static const char kLdPreload[] = "LD_PRELOAD=/data/adb/ksu/lib/libadbroot.so";
+    static const char kLdLibraryPath[] = "LD_LIBRARY_PATH=/data/adb/ksu/lib";
+    static const size_t kReadEnvBatch = 16;
+    static const size_t kPtrSize = sizeof(unsigned long);
+    unsigned long stackp = user_stack_pointer(regs);
+    unsigned long envp, ld_preload_p, ld_library_path_p;
+    unsigned long *envp_p = (unsigned long *)&PT_REGS_PARM3(regs);
+    unsigned long *tmp_env_p = NULL, *tmp_env_p2 = NULL;
+    size_t env_count = 0, total_size;
+    long ret;
 
+    envp = (char __user **)untagged_addr((unsigned long)*envp_p);
+
+    ld_preload_p = stackp = ALIGN_DOWN(stackp - sizeof(kLdPreload), 8);
+    ret = copy_to_user((void __user *)ld_preload_p, kLdPreload, sizeof(kLdPreload));
+    if (ret != 0) {
+        pr_warn("write ld_preload when adb_root_handle_execve failed: %ld\n", ret);
+        return -EFAULT;
+    }
+
+    ld_library_path_p = stackp = ALIGN_DOWN(stackp - sizeof(kLdLibraryPath), 8);
+    ret = copy_to_user((void __user *)ld_library_path_p, kLdLibraryPath, sizeof(kLdLibraryPath));
+    if (ret != 0) {
+        pr_warn("write ld_library_path when adb_root_handle_execve failed: %ld\n", ret);
+        return -EFAULT;
+    }
+
+    for (;;) {
+        tmp_env_p2 = krealloc(tmp_env_p, (env_count + kReadEnvBatch + 2) * kPtrSize, GFP_KERNEL);
+        if (tmp_env_p2 == NULL) {
+            pr_err("alloc tmp env failed\n");
+            ret = -ENOMEM;
+            goto out_release_env_p;
+        }
+        tmp_env_p = tmp_env_p2;
+        ret = copy_from_user(&tmp_env_p[env_count], (void __user *)(envp + env_count * kPtrSize), kReadEnvBatch * kPtrSize);
+        if (ret < 0) {
+            pr_warn("Access envp when adb_root_handle_execve failed: %ld\n", ret);
+            ret = -EFAULT;
+            goto out_release_env_p;
+        }
+        size_t read_count = kReadEnvBatch * kPtrSize - ret;
+        size_t max_new_env_count = read_count / kPtrSize, new_env_count = 0;
+        bool meet_zero = false;
+        for (; new_env_count < max_new_env_count; new_env_count++) {
+            if (!tmp_env_p[new_env_count + env_count]) {
+                meet_zero = true;
+                break;
+            }
+        }
+        if (!meet_zero) {
+            if (read_count % kPtrSize != 0) {
+                pr_err("unaligned envp array!\n");
+                ret = -EFAULT;
+                goto out_release_env_p;
+            } else if (ret != 0) {
+                pr_err("truncated envp array!\n");
+                ret = -EFAULT;
+                goto out_release_env_p;
+            }
+        }
+        env_count += new_env_count;
+        if (meet_zero)
+            break;
+    }
+
+    // We should have allocated enough memory
+    // TODO: handle existing LD_PRELOAD
+    tmp_env_p[env_count++] = ld_preload_p;
+    tmp_env_p[env_count++] = ld_library_path_p;
+    tmp_env_p[env_count++] = 0;
+    total_size = env_count * kPtrSize;
+
+    stackp -= total_size;
+    ret = copy_to_user((void __user *)stackp, tmp_env_p, total_size);
+    if (ret != 0) {
+        pr_err("copy new env failed: %ld\n", ret);
+        ret = -EFAULT;
+        goto out_release_env_p;
+    }
+
+    *envp_p = stackp;
+    ret = 0;
+
+out_release_env_p:
+    if (tmp_env_p) {
+        kfree(tmp_env_p);
+    }
+
+    return ret;
+}
+#endif
+
+#ifdef CONFIG_KSU_SUSFS
+static long do_ksu_adb_root_handle_execve(const char *filename, void ***envp_user_ptr)
+{
+    if (likely(is_exec_adbd(filename) != 1)) {
+        return 0;
+    }
+
+    if (unlikely(is_libadbroot_ok() != 1)) {
+        return 0;
+    }
+
+    long ret = setup_ld_preload(envp_user_ptr);
+    if (ret) {
+        return ret;
+    }
+
+    pr_info("escape to root for adb\n");
+    escape_to_root_for_adb_root();
+
+    ret = (long)escape_with_root_profile();
+    if (ret)
+        pr_err("escape_with_root_profile() failed: %d\n", (int)ret);
+
+    return 0;
+}
+#else
 static long do_ksu_adb_root_handle_execve(struct pt_regs *regs)
 {
     if (likely(is_exec_adbd(regs) != 1)) {
@@ -178,7 +317,17 @@ static long do_ksu_adb_root_handle_execve(struct pt_regs *regs)
     escape_to_root_for_adb_root();
     return 0;
 }
+#endif
 
+#ifdef CONFIG_KSU_SUSFS
+long ksu_adb_root_handle_execve(const char *filename, void ***envp_user_ptr)
+{
+    if (static_branch_unlikely(&ksu_adb_root)) {
+        return do_ksu_adb_root_handle_execve(filename, envp_user_ptr);
+    }
+    return 0;
+}
+#else
 long ksu_adb_root_handle_execve(struct pt_regs *regs)
 {
     if (static_branch_unlikely(&ksu_adb_root)) {
@@ -186,6 +335,7 @@ long ksu_adb_root_handle_execve(struct pt_regs *regs)
     }
     return 0;
 }
+#endif
 
 static int kernel_adb_root_feature_get(u64 *value)
 {

--- a/kernel/feature/adb_root.h
+++ b/kernel/feature/adb_root.h
@@ -2,7 +2,11 @@
 #define __KSU_H_ADB_ROOT
 #include <asm/ptrace.h>
 
+#ifdef CONFIG_KSU_SUSFS
+long ksu_adb_root_handle_execve(const char *filename, void __user ***envp_user_ptr);
+#else
 long ksu_adb_root_handle_execve(struct pt_regs *regs);
+#endif
 
 void ksu_adb_root_init(void);
 

--- a/kernel/feature/kernel_umount.c
+++ b/kernel/feature/kernel_umount.c
@@ -83,6 +83,7 @@ int ksu_handle_umount(uid_t old_uid, uid_t new_uid)
 		return 0;
 	}
 
+#ifndef CONFIG_KSU_SUSFS
 	// There are 6 scenarios:
 	// 1. Normal app: zygote -> appuid
 	// 2. Isolated process forked from zygote: zygote -> isolated_process
@@ -107,6 +108,8 @@ int ksu_handle_umount(uid_t old_uid, uid_t new_uid)
 		pr_info("handle umount ignore non zygote child: %d\n", current->pid);
 		return 0;
 	}
+#endif
+
 	// umount the target mnt
 	pr_info("handle umount for uid: %d, pid: %d\n", new_uid, current->pid);
 
@@ -125,14 +128,14 @@ int ksu_handle_umount(uid_t old_uid, uid_t new_uid)
 	return 0;
 }
 
-void __init ksu_kernel_umount_init(void)
+// kernel_umount: when a process is setuid, if it is an app, we umount all modules
+// for it.
+void __init ksu_kernel_umount_init()
 {
-	if (ksu_register_feature_handler(&kernel_umount_handler)) {
-		pr_err("Failed to register kernel_umount feature handler\n");
-	}
+	ksu_register_feature_handler(&kernel_umount_handler);
 }
 
-void __exit ksu_kernel_umount_exit(void)
+void __exit ksu_kernel_umount_exit()
 {
 	ksu_unregister_feature_handler(KSU_FEATURE_KERNEL_UMOUNT);
 }

--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -10,10 +10,12 @@
 #include <linux/printk.h>
 #include <linux/string.h>
 #include <linux/fs.h>
+#include <linux/types.h>
 #include <asm-generic/errno-base.h>
 #include <net/genetlink.h>
 #include <linux/moduleparam.h>
 #include <linux/mutex.h>
+#include <linux/version.h>
 // security/selinux/include/security.h
 #include <security.h>
 #include <ss/context.h>
@@ -22,17 +24,33 @@
 #include <ss/conditional.h>
 #include "avc.h"
 #include "klog.h" // IWYU pragma: keep
-#include "linux/kallsyms.h"
 #include "objsec.h"
-#include "hook/patch_memory.h"
 #include "ksu.h"
 #include "policy/feature.h"
+#include "hook/patch_memory.h"
 #include "hook/lsm_hook.h"
 
 static DEFINE_MUTEX(selinux_hide_mutex);
-static bool ksu_selinux_hide_enabled __read_mostly = false;
-static bool ksu_selinux_hide_running __read_mostly = false;
+bool ksu_selinux_hide_enabled __read_mostly = false;
+bool ksu_selinux_hide_running __read_mostly = false;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+static int security_context_to_sid_with_policy(struct selinux_policy *policy, const char *scontext, u32 scontext_len,
+                                               u32 *sid, u32 def_sid, gfp_t gfp_flags);
+static int security_sid_to_context_with_policy(struct selinux_policy *policy, u32 sid, char **scontext,
+                                               u32 *scontext_len);
+static void security_compute_av_user_with_policy(struct selinux_policy *policy, u32 ssid, u32 tsid, u16 tclass,
+                                                 struct av_decision *avd);
+static void (*security_dump_masked_av_fn)(struct policydb *policydb, struct context *scontext, struct context *tcontext,
+                                          u16 tclass, u32 permissions, const char *reason) = NULL;
+static void (*context_struct_compute_av_fn)(struct policydb *policydb, struct context *scontext,
+                                            struct context *tcontext, u16 tclass, struct av_decision *avd,
+                                            struct extended_perms *xperms) = NULL;
+#else
+struct selinux_state fake_state = {0};
+#endif
+
+#ifndef CONFIG_KSU_SUSFS
 enum sel_inos {
     SEL_ROOT_INO = 2,
     SEL_LOAD, /* load policy */
@@ -60,25 +78,13 @@ enum sel_inos {
 typedef ssize_t (*write_op_fn)(struct file *, char *, size_t);
 
 static write_op_fn *selinux_write_op;
-
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
-static int security_context_to_sid_with_policy(struct selinux_policy *policy, const char *scontext, u32 scontext_len,
-                                               u32 *sid, u32 def_sid, gfp_t gfp_flags);
-static int security_sid_to_context_with_policy(struct selinux_policy *policy, u32 sid, char **scontext,
-                                               u32 *scontext_len);
-static void security_compute_av_user_with_policy(struct selinux_policy *policy, u32 ssid, u32 tsid, u16 tclass,
-                                                 struct av_decision *avd);
-static void (*security_dump_masked_av_fn)(struct policydb *policydb, struct context *scontext, struct context *tcontext,
-                                          u16 tclass, u32 permissions, const char *reason) = NULL;
-static void (*context_struct_compute_av_fn)(struct policydb *policydb, struct context *scontext,
-                                            struct context *tcontext, u16 tclass, struct av_decision *avd,
-                                            struct extended_perms *xperms) = NULL;
-#else
-static struct selinux_state fake_state;
-#endif
-
 static write_op_fn *context_write, *access_write;
 static write_op_fn orig_context_write, orig_access_write;
+
+static int my_setprocattr(const char *name, void *value, size_t size);
+struct ksu_lsm_hook selinux_setprocattr_hook = KSU_LSM_HOOK_INIT(setprocattr, "selinux_setprocattr", my_setprocattr, 0);
+
+typedef int (*setprocattr_fn)(const char *name, void *value, size_t size);
 
 static ssize_t my_write_context(struct file *file, char *buf, size_t size)
 {
@@ -196,10 +202,6 @@ out:
     return length;
 }
 
-static int my_setprocattr(const char *name, void *value, size_t size);
-struct ksu_lsm_hook selinux_setprocattr_hook = KSU_LSM_HOOK_INIT(setprocattr, "selinux_setprocattr", my_setprocattr, 0);
-
-typedef int (*setprocattr_fn)(const char *name, void *value, size_t size);
 static int __nocfi my_setprocattr(const char *name, void *value, size_t size)
 {
     int error;
@@ -241,11 +243,12 @@ static int __nocfi my_setprocattr(const char *name, void *value, size_t size)
 call_orig:
     return ((setprocattr_fn)selinux_setprocattr_hook.original)(name, value, size);
 }
+#endif // #ifndef CONFIG_KSU_SUSFS
 
-static DEFINE_STATIC_KEY_FALSE(fake_status_initialize_key);
-static struct page *fake_status = NULL;
+DEFINE_STATIC_KEY_FALSE(fake_status_initialize_key);
+struct page *fake_status = NULL;
 
-static void initialize_fake_status()
+void initialize_fake_status()
 {
     mutex_lock(&selinux_state.status_lock);
     if (fake_status)
@@ -308,21 +311,51 @@ static int my_sel_open_handle_status(struct inode *inode, struct file *filp)
 }
 
 static void hook_selinux_status_open();
-static void ksu_selinux_hide_unhook();
+static void ksu_selinux_hide_unhook()
+{
+#ifndef CONFIG_KSU_SUSFS
+    int ret;
+    if (orig_context_write) {
+        ret =
+            ksu_patch_text(context_write, &orig_context_write, sizeof(orig_context_write), KSU_PATCH_TEXT_FLUSH_DCACHE);
+        orig_context_write = NULL;
+        if (ret) {
+            pr_err("selinux_hide: exit: patch_text context_write err: %d\n", ret);
+        }
+    }
+    if (orig_access_write) {
+        ret = ksu_patch_text(access_write, &orig_access_write, sizeof(orig_access_write), KSU_PATCH_TEXT_FLUSH_DCACHE);
+        orig_access_write = NULL;
+        if (ret) {
+            pr_err("selinux_hide: exit: patch_text access_write err: %d\n", ret);
+        }
+    }
+    ksu_lsm_unhook(&selinux_setprocattr_hook);
+#endif // #ifndef CONFIG_KSU_SUSFS
+
+    if (sel_open_handle_status_slot && orig_sel_open_handle_status) {
+        int ret = ksu_patch_text(sel_open_handle_status_slot, &orig_sel_open_handle_status,
+                             sizeof(orig_sel_open_handle_status), KSU_PATCH_TEXT_FLUSH_DCACHE);
+        orig_sel_open_handle_status = NULL;
+        if (ret) {
+            pr_err("selinux_hide: exit: patch_text sel_open_handle_status err: %d\n", ret);
+        }
+    }
+}
+
+static void ksu_selinux_hide_disable()
+{
+    pr_info("selinux_hide: exit selinux hide\n");
+    ksu_selinux_hide_unhook();
+}
+
 static int ksu_selinux_hide_enable()
 {
-    int ret;
     pr_info("selinux_hide: init selinux hide\n");
     if (!backup_sepolicy) {
         pr_err("no backup sepolicy available, please save feature and reboot to retry!\n");
         return -EAGAIN;
     }
-    selinux_write_op = find_kernel_symbol_exact("write_op");
-    if (!selinux_write_op) {
-        pr_err("selinux_hide: no write_op found!\n");
-        return -ENOSYS;
-    }
-    hook_selinux_status_open();
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
     security_dump_masked_av_fn = find_kernel_symbol_exact("security_dump_masked_av");
@@ -337,6 +370,14 @@ static int ksu_selinux_hide_enable()
     fake_state.initialized = true;
     fake_state.policy = backup_sepolicy;
 #endif
+
+#ifndef CONFIG_KSU_SUSFS
+    int ret;
+    selinux_write_op = find_kernel_symbol_exact("write_op");
+    if (!selinux_write_op) {
+        pr_err("selinux_hide: no write_op found!\n");
+        return -ENOSYS;
+    }
 
     context_write = &selinux_write_op[SEL_CONTEXT];
     pr_info("selinux_hide: context_write: 0x%lx [%pSb]\n", (unsigned long)*context_write, *context_write);
@@ -363,47 +404,17 @@ static int ksu_selinux_hide_enable()
         pr_err("selinux_hide: init: selinux_setprocattr_hook err: %d\n", ret);
         goto unhook;
     }
+#endif // #ifndef CONFIG_KSU_SUSFS
+
+    hook_selinux_status_open();
 
     return 0;
 
+#ifndef CONFIG_KSU_SUSFS
 unhook:
     ksu_selinux_hide_unhook();
     return -ENOSYS;
-}
-
-static void ksu_selinux_hide_unhook()
-{
-    int ret;
-    if (orig_context_write) {
-        ret =
-            ksu_patch_text(context_write, &orig_context_write, sizeof(orig_context_write), KSU_PATCH_TEXT_FLUSH_DCACHE);
-        orig_context_write = NULL;
-        if (ret) {
-            pr_err("selinux_hide: exit: patch_text context_write err: %d\n", ret);
-        }
-    }
-    if (orig_access_write) {
-        ret = ksu_patch_text(access_write, &orig_access_write, sizeof(orig_access_write), KSU_PATCH_TEXT_FLUSH_DCACHE);
-        orig_access_write = NULL;
-        if (ret) {
-            pr_err("selinux_hide: exit: patch_text access_write err: %d\n", ret);
-        }
-    }
-    if (sel_open_handle_status_slot && orig_sel_open_handle_status) {
-        ret = ksu_patch_text(sel_open_handle_status_slot, &orig_sel_open_handle_status,
-                             sizeof(orig_sel_open_handle_status), KSU_PATCH_TEXT_FLUSH_DCACHE);
-        orig_sel_open_handle_status = NULL;
-        if (ret) {
-            pr_err("selinux_hide: exit: patch_text sel_open_handle_status err: %d\n", ret);
-        }
-    }
-    ksu_lsm_unhook(&selinux_setprocattr_hook);
-}
-
-static void ksu_selinux_hide_disable()
-{
-    pr_info("selinux_hide: exit selinux hide\n");
-    ksu_selinux_hide_unhook();
+#endif
 }
 
 static int selinux_hide_feature_get(u64 *value)
@@ -432,6 +443,8 @@ static int selinux_hide_feature_set(u64 value)
             ksu_selinux_hide_running = false;
         }
     }
+    pr_info("selinux_hide: ksu_selinux_hide_enabled: %d, ksu_selinux_hide_running: %d\n",
+            ksu_selinux_hide_enabled, ksu_selinux_hide_running);
     mutex_unlock(&selinux_hide_mutex);
     return ret;
 }
@@ -605,7 +618,7 @@ out:
     return rc;
 }
 
-static int security_context_to_sid_with_policy(struct selinux_policy *policy, const char *scontext, u32 scontext_len,
+int security_context_to_sid_with_policy(struct selinux_policy *policy, const char *scontext, u32 scontext_len,
                                                u32 *sid, u32 def_sid, gfp_t gfp_flags)
 {
     struct policydb *policydb;
@@ -712,7 +725,7 @@ static int sidtab_entry_to_string(struct policydb *p, struct sidtab *sidtab, str
     return rc;
 }
 
-static int security_sid_to_context_with_policy(struct selinux_policy *policy, u32 sid, char **scontext,
+int security_sid_to_context_with_policy(struct selinux_policy *policy, u32 sid, char **scontext,
                                                u32 *scontext_len)
 {
     struct policydb *policydb;
@@ -899,7 +912,7 @@ static int constraint_expr_eval(struct policydb *policydb, struct context *scont
                 l2 = &(scontext->range.level[1]);
                 goto mls_ops;
             case CEXPR_L2H2:
-                l1 = &(tcontext->range.level[0]);
+                l1 = &(scontext->range.level[0]);
                 l2 = &(tcontext->range.level[1]);
                 goto mls_ops;
             mls_ops:
@@ -1085,7 +1098,7 @@ static void context_struct_compute_av(struct policydb *policydb, struct context 
     type_attribute_bounds_av(policydb, scontext, tcontext, tclass, avd);
 }
 
-static void __nocfi security_compute_av_user_with_policy(struct selinux_policy *policy, u32 ssid, u32 tsid, u16 tclass,
+void __nocfi security_compute_av_user_with_policy(struct selinux_policy *policy, u32 ssid, u32 tsid, u16 tclass,
                                                          struct av_decision *avd)
 {
     struct policydb *policydb;

--- a/kernel/feature/selinux_hide.h
+++ b/kernel/feature/selinux_hide.h
@@ -1,10 +1,25 @@
 #ifndef __KSU_H_SELINUX_HIDE
 #define __KSU_H_SELINUX_HIDE
 
+#include <linux/types.h>
+
 void ksu_selinux_hide_init();
 void ksu_selinux_hide_exit();
 void ksu_selinux_hide_drop_backup_if_unused();
 void ksu_selinux_hide_handle_second_stage();
 void ksu_selinux_hide_handle_post_fs_data();
+
+extern bool ksu_selinux_hide_running;
+extern bool ksu_selinux_hide_enabled;
+extern void initialize_fake_status(void);
+
+struct page;
+extern struct page *fake_status;
+
+struct static_key_false;
+extern struct static_key_false fake_status_initialize_key;
+
+struct selinux_state;
+extern struct selinux_state fake_state;
 
 #endif

--- a/kernel/feature/sucompat.c
+++ b/kernel/feature/sucompat.c
@@ -137,6 +137,35 @@ static const char __user *get_user_arg_ptr(struct user_arg_ptr argv, int nr)
 	return native;
 }
 
+static bool ksu_str_ends_with(const char *str, size_t str_len, const char *suffix)
+{
+    size_t suffix_len = strlen(suffix);
+    if (suffix_len > str_len)
+        return false;
+    return memcmp(str + str_len - suffix_len, suffix, suffix_len) == 0;
+}
+
+static bool ksu_is_zygote_or_adbd(const char *name, size_t len)
+{
+    if (len < 5)
+        return false;
+
+    // Fast-path: Check last character first to skip 99% of processes
+    char last = name[len - 1];
+    if (last == 'd')
+        return ksu_str_ends_with(name, len, "/adbd");
+    if (last == 's')
+        return ksu_str_ends_with(name, len, "/app_process");
+    if (last == '2')
+        return ksu_str_ends_with(name, len, "/app_process32");
+    if (last == '4')
+        return ksu_str_ends_with(name, len, "/app_process64");
+    if (last == 'e')
+        return ksu_str_ends_with(name, len, "/stub_zygote");
+
+    return false;
+}
+
 /*
  * return 0 -> No further checks should be required afterwards
  * return non-zero -> Further checks should be continued afterwards
@@ -161,14 +190,15 @@ int ksu_handle_execveat_init(struct filename *filename, struct user_arg_ptr *arg
             pending_sucompat = ksu_sulog_capture_sucompat_kernel(filename->name, (const char __user *const __user *)argv_user->ptr.native, GFP_KERNEL);
             ksu_sulog_emit_pending(pending_sucompat, ret, GFP_KERNEL);
             return 0;
-        } else if (likely(strstr(filename->name, "/app_process") == NULL &&
-                    strstr(filename->name, "/adbd") == NULL &&
-                    strstr(filename->name, "/stub_zygote") == NULL) &&
-                    !susfs_is_current_proc_umounted())
-        {
-            pr_info("susfs: mark no sucompat checks for pid: '%d', exec: '%s'\n", current->pid, filename->name);
-            susfs_set_current_proc_umounted();
-            return 0;
+        } else {
+            size_t len = strlen(filename->name);
+            if (likely(!ksu_is_zygote_or_adbd(filename->name, len)) &&
+                        !susfs_is_current_proc_umounted())
+            {
+                pr_info("susfs: mark no sucompat checks for pid: '%d', exec: '%s'\n", current->pid, filename->name);
+                susfs_set_current_proc_umounted();
+                return 0;
+            }
         }
 
 #ifdef CONFIG_COMPAT

--- a/kernel/feature/sucompat.c
+++ b/kernel/feature/sucompat.c
@@ -13,6 +13,19 @@
 #include <linux/version.h>
 #include <linux/sched/task_stack.h>
 #include <linux/ptrace.h>
+#include <linux/namei.h>
+
+#include "linux/jump_label.h"
+
+#include <linux/fs_struct.h>
+
+#ifdef CONFIG_KSU_SUSFS
+#include <linux/susfs_def.h>
+#include <linux/minmax.h>
+#include "selinux/selinux.h"
+#include "objsec.h"
+#include "runtime/ksud.h"
+#endif
 
 #include "arch.h"
 #include "policy/allowlist.h"
@@ -20,6 +33,7 @@
 #include "klog.h" // IWYU pragma: keep
 #include "runtime/ksud.h"
 #include "feature/sucompat.h"
+#include "feature/adb_root.h"
 #include "policy/app_profile.h"
 #include "hook/syscall_hook.h"
 #include "sulog/event.h"
@@ -29,18 +43,28 @@
 #define SU_PATH "/system/bin/su"
 #define SH_PATH "/system/bin/sh"
 
-bool ksu_su_compat_enabled __read_mostly = true;
+static const char sh_path[] = SH_PATH;
+static const char su_path[] = SU_PATH;
+static const char ksud_path[] = KSUD_PATH;
+
+DEFINE_STATIC_KEY_TRUE(ksu_su_compat_enabled);
 
 static int su_compat_feature_get(u64 *value)
 {
-	*value = ksu_su_compat_enabled ? 1 : 0;
+	if (static_key_enabled(&ksu_su_compat_enabled))
+		*value = 1;
+	else
+		*value = 0;
 	return 0;
 }
 
 static int su_compat_feature_set(u64 value)
 {
 	bool enable = value != 0;
-	ksu_su_compat_enabled = enable;
+	if (enable)
+		static_branch_enable(&ksu_su_compat_enabled);
+	else
+		static_branch_disable(&ksu_su_compat_enabled);
 	pr_info("su_compat: set to %d\n", enable);
 	return 0;
 }
@@ -61,19 +85,24 @@ static void __user *userspace_stack_buffer(const void *d, size_t len)
 	return copy_to_user(p, d, len) ? NULL : p;
 }
 
+static char __user *sh_user_path(void)
+{
+	static const char sh_path_local[] = "/system/bin/sh";
+
+	return userspace_stack_buffer(sh_path_local, sizeof(sh_path_local));
+}
+
 static char __user *ksud_user_path(void)
 {
-	static const char ksud_path[] = KSUD_PATH;
+	static const char ksud_path_local[] = KSUD_PATH;
 
-	return userspace_stack_buffer(ksud_path, sizeof(ksud_path));
+	return userspace_stack_buffer(ksud_path_local, sizeof(ksud_path_local));
 }
 
 static char __user *empty_user_path(void)
 {
 	return userspace_stack_buffer("", sizeof(""));
 }
-
-static const char su_path[] = SU_PATH;
 
 static bool is_ksud_exists()
 {
@@ -86,6 +115,275 @@ static bool is_ksud_exists()
 	return true;
 }
 
+#ifdef CONFIG_KSU_SUSFS
+static const char __user *get_user_arg_ptr(struct user_arg_ptr argv, int nr)
+{
+	const char __user *native;
+
+#ifdef CONFIG_COMPAT
+	if (unlikely(argv.is_compat)) {
+		compat_uptr_t compat;
+
+		if (get_user(compat, argv.ptr.compat + nr))
+			return ERR_PTR(-EFAULT);
+
+		return compat_ptr(compat);
+	}
+#endif
+
+	if (get_user(native, argv.ptr.native + nr))
+		return ERR_PTR(-EFAULT);
+
+	return native;
+}
+
+/*
+ * return 0 -> No further checks should be required afterwards
+ * return non-zero -> Further checks should be continued afterwards
+ */
+int ksu_handle_execveat_init(struct filename *filename, struct user_arg_ptr *argv_user, struct user_arg_ptr *envp_user) {
+    if (current->pid != 1 && is_init(get_current_cred())) {
+        int ret;
+        if (unlikely(strcmp(filename->name, KSUD_PATH) == 0)) {
+            const char __user *argv_user_ptr = get_user_arg_ptr(*argv_user, 0);
+            struct ksu_sulog_pending_event *pending_sucompat = NULL;
+
+            pr_info("hook_manager: escape to root for init executing ksud: %d\n", current->pid);
+            ret = escape_to_root_for_init();
+            if (ret) {
+                pr_err("escape_to_root_for_init() failed: %d\n", ret);
+                return ret;
+            }
+            if (!argv_user_ptr || IS_ERR(argv_user_ptr)) {
+                pr_err("!argv_user_ptr || IS_ERR(argv_user_ptr)\n");
+                return -EFAULT;
+            }
+            pending_sucompat = ksu_sulog_capture_sucompat_kernel(filename->name, (const char __user *const __user *)argv_user->ptr.native, GFP_KERNEL);
+            ksu_sulog_emit_pending(pending_sucompat, ret, GFP_KERNEL);
+            return 0;
+        } else if (likely(strstr(filename->name, "/app_process") == NULL &&
+                    strstr(filename->name, "/adbd") == NULL &&
+                    strstr(filename->name, "/stub_zygote") == NULL) &&
+                    !susfs_is_current_proc_umounted())
+        {
+            pr_info("susfs: mark no sucompat checks for pid: '%d', exec: '%s'\n", current->pid, filename->name);
+            susfs_set_current_proc_umounted();
+            return 0;
+        }
+
+#ifdef CONFIG_COMPAT
+        if (unlikely(envp_user->is_compat))
+            ret = ksu_adb_root_handle_execve(filename->name, (void ***)&envp_user->ptr.compat);
+        else
+            ret = ksu_adb_root_handle_execve(filename->name, (void ***)&envp_user->ptr.native);
+#else
+        ret = ksu_adb_root_handle_execve(filename->name, (void ***)&envp_user->ptr.native);
+#endif
+
+        if (ret) {
+            pr_err("adb root failed: %d\n", ret);
+            return ret;
+        }
+        return ret;
+    }
+
+    return -EINVAL;
+}
+
+int ksu_handle_execveat_sucompat(int *fd, struct filename **filename_ptr,
+                 void *argv_user, void *envp_user,
+                 int *__never_use_flags)
+{
+    struct filename *filename;
+    struct user_arg_ptr *argv_ptr = (struct user_arg_ptr *)argv_user;
+    struct ksu_sulog_pending_event *pending_sucompat = NULL;
+    int ret;
+
+    if (unlikely(!filename_ptr))
+        return 0;
+
+    filename = *filename_ptr;
+    if (IS_ERR(filename))
+        return 0;
+
+    if (!ksu_handle_execveat_init(filename, (struct user_arg_ptr*)argv_user, (struct user_arg_ptr*)envp_user))
+        return 0;
+
+    if (likely(memcmp(filename->name, su_path, sizeof(su_path))))
+        return 0;
+
+    if (current_chrooted())
+    {
+        pr_err("ksu_handle_execveat_sucompat: su found but NOT allowed! Because current process is running in chrooted environment\n");
+        return 0;
+    }
+
+    if (!ksu_is_allow_uid_for_current(current_uid().val))
+        return 0;
+
+    ksu_compat_sulog('x');
+    pr_info("ksu_handle_execveat_sucompat: su found\n");
+
+    pending_sucompat = ksu_sulog_capture_sucompat_kernel(filename->name,
+                                                         (const char __user *const __user *)argv_ptr->ptr.native,
+                                                         GFP_KERNEL);
+
+    memcpy((void *)filename->name, ksud_path, sizeof(ksud_path));
+
+    ret = escape_with_root_profile();
+    if (ret)
+        pr_err("escape_with_root_profile() failed: %d\n", ret);
+
+    ksu_sulog_emit_pending(pending_sucompat, ret, GFP_KERNEL);
+
+    return 0;
+}
+
+extern struct static_key_true is_first_zygote;
+
+int ksu_handle_execveat(int *fd, struct filename **filename_ptr, void *argv,
+            void *envp, int *flags)
+{
+    struct ksu_sulog_pending_event *pending_root_execve = NULL;
+
+    if (unlikely(!filename_ptr))
+        return 0;
+
+    if (IS_ERR(*filename_ptr))
+        return 0;
+
+    if (current_euid().val == 0) {
+        struct user_arg_ptr *argv_ptr = (struct user_arg_ptr *)argv;
+        pending_root_execve = ksu_sulog_capture_root_execve_kernel((*filename_ptr)->name,
+                                                                   (const char __user *const __user *)argv_ptr->ptr.native,
+                                                                   GFP_KERNEL);
+        ksu_sulog_emit_pending(pending_root_execve, 0, GFP_KERNEL);
+    }
+
+    if (static_branch_unlikely(&is_first_zygote)) {
+        if (ksu_handle_execveat_ksud(fd, filename_ptr, argv, envp, flags))
+            return 0;
+    }
+
+    return ksu_handle_execveat_sucompat(fd, filename_ptr, argv, envp,
+                        flags);
+}
+#endif
+
+int ksu_handle_faccessat(int *dfd, const char __user **filename_user,
+		int *mode, int *__unused_flags)
+{
+#ifdef CONFIG_KSU_SUSFS
+    char path[sizeof(su_path) + 1] = {0};
+    if (strncpy_from_user_nofault(path, *filename_user, sizeof(path)) < 0)
+        return 0;
+
+    if (unlikely(!memcmp(path, su_path, sizeof(su_path)))) {
+        if (current_chrooted())
+        {
+            pr_err("ksu_handle_faccessat: su found but NOT allowed! Because current process is running in chrooted environment\n");
+            return 0;
+        }
+
+        if (!ksu_is_allow_uid_for_current(current_uid().val))
+            return 0;
+
+        ksu_compat_sulog('a');
+        pr_info("ksu_handle_faccessat: su->sh!\n");
+        *filename_user = sh_user_path();
+    }
+#else
+	const char su[] = SU_PATH;
+
+	if (!ksu_is_allow_uid_for_current(current_uid().val)) {
+		return 0;
+	}
+
+	char path[sizeof(su) + 1];
+	memset(path, 0, sizeof(path));
+	strncpy_from_user_nofault(path, *filename_user, sizeof(path));
+
+	if (unlikely(!memcmp(path, su, sizeof(su)))) {
+		ksu_compat_sulog('a');
+		pr_info("faccessat su->sh!\n");
+		*filename_user = sh_user_path();
+	}
+#endif
+
+	return 0;
+}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0) && defined(CONFIG_KSU_SUSFS)
+int ksu_handle_stat(int *dfd, struct filename **filename, int *flags) {
+    if (unlikely(IS_ERR(*filename) || (*filename)->name == NULL))
+        return 0;
+
+    if (likely(memcmp((*filename)->name, su_path, sizeof(su_path))))
+        return 0;
+
+    if (current_chrooted())
+    {
+        pr_err("ksu_handle_stat: su found but NOT allowed! Because current process is running in chrooted environment\n");
+        return 0;
+    }
+
+    if (!ksu_is_allow_uid_for_current(current_uid().val))
+        return 0;
+
+    ksu_compat_sulog('s');
+    pr_info("ksu_handle_stat: su->sh!\n");
+    memcpy((void *)((*filename)->name), sh_path, sizeof(sh_path));
+    return 0;
+}
+#else
+int ksu_handle_stat(int *dfd, const char __user **filename_user, int *flags)
+{
+#ifdef CONFIG_KSU_SUSFS
+    char path[sizeof(su_path) + 1] = {0};
+    if (strncpy_from_user_nofault(path, *filename_user, sizeof(path)) < 0)
+        return 0;
+
+    if (unlikely(!memcmp(path, su_path, sizeof(su_path)))) {
+        if (current_chrooted())
+        {
+            pr_err("ksu_handle_stat: su found but NOT allowed! Because current process is running in chrooted environment\n");
+            return 0;
+        }
+
+        if (!ksu_is_allow_uid_for_current(current_uid().val))
+            return 0;
+
+        ksu_compat_sulog('s');
+        pr_info("ksu_handle_stat: su->sh!\n");
+        *filename_user = sh_user_path();
+    }
+#else
+	const char su[] = SU_PATH;
+
+	if (!ksu_is_allow_uid_for_current(current_uid().val)) {
+		return 0;
+	}
+
+	if (unlikely(!filename_user)) {
+		return 0;
+	}
+
+	char path[sizeof(su) + 1];
+	memset(path, 0, sizeof(path));
+	strncpy_from_user_nofault(path, *filename_user, sizeof(path));
+
+	if (unlikely(!memcmp(path, su, sizeof(su)))) {
+		ksu_compat_sulog('s');
+		pr_info("newfstatat su->sh!\n");
+		*filename_user = sh_user_path();
+	}
+#endif
+
+	return 0;
+}
+#endif
+
+#if defined(CONFIG_KPROBES) && !defined(CONFIG_KSU_SUSFS)
 long ksu_handle_faccessat_sucompat(int orig_nr, struct pt_regs *regs)
 {
 	const char __user **filename_user, *orig_filename;
@@ -103,6 +401,10 @@ long ksu_handle_faccessat_sucompat(int orig_nr, struct pt_regs *regs)
 	strncpy_from_user_nofault(path, *filename_user, sizeof(path));
 
 	if (unlikely(!memcmp(path, su_path, sizeof(su_path)))) {
+		if (current_chrooted()) {
+			pr_err("ksu_handle_faccessat_sucompat: su found but NOT allowed! Because current process is running in chrooted environment\n");
+			goto do_orig_facessat;
+		}
 		old_cred = override_creds(ksu_cred);
 		if (is_ksud_exists()) {
 			ksu_compat_sulog('a');
@@ -139,6 +441,10 @@ long ksu_handle_stat_sucompat(int orig_nr, struct pt_regs *regs)
 	strncpy_from_user_nofault(path, *filename_user, sizeof(path));
 
 	if (unlikely(!memcmp(path, su_path, sizeof(su_path)))) {
+		if (current_chrooted()) {
+			pr_err("ksu_handle_stat_sucompat: su found but NOT allowed! Because current process is running in chrooted environment\n");
+			goto do_orig_stat;
+		}
 		old_cred = override_creds(ksu_cred);
 		if (is_ksud_exists()) {
 			ksu_compat_sulog('s');
@@ -188,6 +494,11 @@ long ksu_handle_execve_sucompat(const char __user **filename_user, int orig_nr, 
 
 	if (likely(memcmp(path, su_path, sizeof(su_path))))
 		goto do_orig_execve;
+
+	if (current_chrooted()) {
+		pr_err("ksu_handle_execve_sucompat: su found but NOT allowed! Because current process is running in chrooted environment\n");
+		goto do_orig_execve;
+	}
 
 	ksu_compat_sulog('x');
 	pr_info("sys_execve su found\n");
@@ -243,6 +554,7 @@ long ksu_handle_execve_sucompat(const char __user **filename_user, int orig_nr, 
 do_orig_execve:
 	return ksu_syscall_table[orig_nr](regs);
 }
+#endif
 
 // sucompat: permitted process can execute 'su' to gain root access.
 void __init ksu_sucompat_init()

--- a/kernel/feature/sucompat.h
+++ b/kernel/feature/sucompat.h
@@ -2,15 +2,34 @@
 #define __KSU_H_SUCOMPAT
 #include <asm/ptrace.h>
 #include <linux/types.h>
+#include <linux/version.h>
 
-extern bool ksu_su_compat_enabled;
+#include "linux/jump_label.h"
+
+extern struct static_key_true ksu_su_compat_enabled;
 
 void ksu_sucompat_init(void);
 void ksu_sucompat_exit(void);
 
 // Handler functions exported for hook_manager
+#ifdef CONFIG_KSU_SUSFS
+int ksu_handle_faccessat(int *dfd, const char __user **filename_user, int *mode,
+                         int *__unused_flags);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+int ksu_handle_stat(int *dfd, struct filename **filename, int *flags);
+#else
+int ksu_handle_stat(int *dfd, const char __user **filename_user, int *flags);
+#endif // #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+
+int ksu_handle_execveat(int *fd, struct filename **filename_ptr, void *argv,
+            void *envp, int *flags);
+int ksu_handle_execveat_init(struct filename *filename, struct user_arg_ptr *argv_user, struct user_arg_ptr *envp_user);
+#else
+#if defined(CONFIG_KPROBES)
 long ksu_handle_faccessat_sucompat(int orig_nr, struct pt_regs *regs);
 long ksu_handle_stat_sucompat(int orig_nr, struct pt_regs *regs);
 long ksu_handle_execve_sucompat(const char __user **filename_user, int orig_nr, struct pt_regs *regs);
+#endif
+#endif
 
 #endif

--- a/kernel/hook/setuid_hook.c
+++ b/kernel/hook/setuid_hook.c
@@ -3,6 +3,7 @@
 #include <linux/slab.h>
 #include <linux/task_work.h>
 #include <linux/thread_info.h>
+#include <linux/cred.h>
 #include <linux/seccomp.h>
 #include <linux/printk.h>
 #include <linux/sched.h>
@@ -11,6 +12,11 @@
 #include <linux/types.h>
 #include <linux/uaccess.h>
 #include <linux/uidgid.h>
+
+#ifdef CONFIG_KSU_SUSFS
+#include <linux/susfs_def.h>
+#include "selinux/selinux.h"
+#endif
 
 #include "policy/allowlist.h"
 #include "hook/setuid_hook.h"
@@ -21,6 +27,69 @@
 #include "hook/tp_marker.h"
 #include "feature/kernel_umount.h"
 
+extern void disable_seccomp(void);
+extern struct cred *ksu_cred;
+
+#ifdef CONFIG_KSU_SUSFS
+extern u32 susfs_zygote_sid;
+extern struct work_struct susfs_extra_works;
+
+static inline void ksu_handle_extra_susfs_work(void)
+{
+    if (work_pending(&susfs_extra_works))
+        return;
+
+    schedule_work(&susfs_extra_works);
+}
+
+int ksu_handle_setresuid(uid_t ruid, uid_t euid, uid_t suid)
+{
+    // We only interest in process spwaned by zygote
+    if (!susfs_is_sid_equal(current_cred(), susfs_zygote_sid))
+        return 0;
+
+    // Check if spawned process is isolated service first, and force to do umount if so
+    if (is_isolated_process(ruid))
+        goto do_umount;
+
+    // - Since ksu maanger app uid is excluded in allow_list_arr, so ksu_uid_should_umount(manager_uid)
+    //   will always return true, that's why we need to explicitly check if new_uid belongs to
+    //   ksu manager.
+    // - Disable seccomp restriction for KSU manager since running with "su" will disable seccomp anyway
+    if (likely(ksu_is_manager_appid_valid()) && unlikely(is_uid_manager(ruid))) {
+        disable_seccomp();
+
+        pr_info("install fd for manager: %d\n", ruid);
+        ksu_install_fd();
+        return 0;
+    }
+
+    // we should not umount for webview zygote
+    if (unlikely(ruid == WEBVIEW_ZYGOTE_UID))
+        return 0;
+
+    // Check if spawned process is normal user app and needs to be umounted
+    if (likely(is_appuid(ruid) && ksu_uid_should_umount(ruid)))
+        goto do_umount;
+
+    if (ksu_is_allow_uid_for_current(ruid))
+        disable_seccomp();
+
+    return 0;
+
+do_umount:
+    // Handle kernel umount
+    ksu_handle_umount(current_uid().val, ruid);
+
+    // Handle extra susfs work
+    ksu_handle_extra_susfs_work();
+
+    // Mark current proc as umounted
+    susfs_set_current_proc_umounted();
+
+    return 0;
+}
+#else
 int ksu_handle_setresuid(uid_t old_uid, uid_t new_uid)
 {
     // we rely on the fact that zygote always call setresuid(3) with same uids
@@ -28,10 +97,8 @@ int ksu_handle_setresuid(uid_t old_uid, uid_t new_uid)
     pr_info("handle_setresuid from %d to %d\n", old_uid, new_uid);
 
     if (unlikely(is_uid_manager(new_uid))) {
-        spin_lock_irq(&current->sighand->siglock);
-        ksu_seccomp_allow_cache(current->seccomp.filter, __NR_reboot);
+        disable_seccomp();
         ksu_set_task_tracepoint_flag(current);
-        spin_unlock_irq(&current->sighand->siglock);
 
         pr_info("install fd for manager: %d\n", new_uid);
         ksu_install_fd();
@@ -39,12 +106,7 @@ int ksu_handle_setresuid(uid_t old_uid, uid_t new_uid)
     }
 
     if (ksu_is_allow_uid_for_current(new_uid)) {
-        if (current->seccomp.mode == SECCOMP_MODE_FILTER &&
-            current->seccomp.filter) {
-            spin_lock_irq(&current->sighand->siglock);
-            ksu_seccomp_allow_cache(current->seccomp.filter, __NR_reboot);
-            spin_unlock_irq(&current->sighand->siglock);
-        }
+        disable_seccomp();
         ksu_set_task_tracepoint_flag(current);
     } else {
         ksu_clear_task_tracepoint_flag_if_needed(current);
@@ -55,6 +117,7 @@ int ksu_handle_setresuid(uid_t old_uid, uid_t new_uid)
 
     return 0;
 }
+#endif
 
 void __init ksu_setuid_hook_init(void)
 {

--- a/kernel/hook/setuid_hook.h
+++ b/kernel/hook/setuid_hook.h
@@ -8,6 +8,10 @@ void ksu_setuid_hook_init(void);
 void ksu_setuid_hook_exit(void);
 
 // Handler functions for hook_manager
+#ifdef CONFIG_KSU_SUSFS
+int ksu_handle_setresuid(uid_t ruid, uid_t euid, uid_t suid);
+#else
 int ksu_handle_setresuid(uid_t old_uid, uid_t new_uid);
+#endif
 
 #endif

--- a/kernel/hook/syscall_event_bridge.c
+++ b/kernel/hook/syscall_event_bridge.c
@@ -45,61 +45,61 @@ static int ksu_handle_init_mark_tracker(const char __user **filename_user)
         ksu_clear_task_tracepoint_flag_if_needed(current);
     }
 
-    return 0;
+	return 0;
 }
 
 long __nocfi ksu_hook_newfstatat(int orig_nr, const struct pt_regs *regs)
 {
-    if (!ksu_su_compat_enabled)
-        return ksu_syscall_table[orig_nr](regs);
+	if (!static_branch_likely(&ksu_su_compat_enabled))
+		return ksu_syscall_table[orig_nr](regs);
 
-    return ksu_handle_stat_sucompat(orig_nr, (struct pt_regs *)regs);
+	return ksu_handle_stat_sucompat(orig_nr, (struct pt_regs *)regs);
 }
 
 long __nocfi ksu_hook_faccessat(int orig_nr, const struct pt_regs *regs)
 {
-    if (!ksu_su_compat_enabled)
-        return ksu_syscall_table[orig_nr](regs);
+	if (!static_branch_likely(&ksu_su_compat_enabled))
+		return ksu_syscall_table[orig_nr](regs);
 
-    return ksu_handle_faccessat_sucompat(orig_nr, (struct pt_regs *)regs);
+	return ksu_handle_faccessat_sucompat(orig_nr, (struct pt_regs *)regs);
 }
 
 DEFINE_STATIC_KEY_TRUE(ksud_execve_key);
 
 void ksu_stop_ksud_execve_hook()
 {
-    static_branch_disable(&ksud_execve_key);
+	static_branch_disable(&ksud_execve_key);
 }
 
 long __nocfi ksu_hook_execve(int orig_nr, const struct pt_regs *regs)
 {
-    const char __user **filename_user = (const char __user **)&PT_REGS_PARM1(regs);
-    const char __user *const __user *argv_user = (const char __user *const __user *)PT_REGS_PARM2(regs);
-    bool current_is_init = is_init(current_cred());
-    struct ksu_sulog_pending_event *pending_root_execve = NULL;
-    long ret;
+	const char __user **filename_user = (const char __user **)&PT_REGS_PARM1(regs);
+	const char __user *const __user *argv_user = (const char __user *const __user *)PT_REGS_PARM2(regs);
+	bool current_is_init = is_init(current_cred());
+	struct ksu_sulog_pending_event *pending_root_execve = NULL;
+	long ret;
 
-    if (static_branch_unlikely(&ksud_execve_key))
-        ksu_execve_hook_ksud(regs);
+	if (static_branch_unlikely(&ksud_execve_key))
+		ksu_execve_hook_ksud(regs);
 
-    if (current_euid().val == 0)
-        pending_root_execve = ksu_sulog_capture_root_execve(*filename_user, argv_user, GFP_KERNEL);
+	if (current_euid().val == 0)
+		pending_root_execve = ksu_sulog_capture_root_execve(*filename_user, argv_user, GFP_KERNEL);
 
-    if (current->pid != 1 && current_is_init) {
-        ksu_handle_init_mark_tracker(filename_user);
-        ret = ksu_adb_root_handle_execve((struct pt_regs *)regs);
-        if (ret) {
-            pr_err("adb root failed: %ld\n", ret);
-        }
-    } else if (ksu_su_compat_enabled) {
-        ret = ksu_handle_execve_sucompat(filename_user, orig_nr, (struct pt_regs *)regs);
-        ksu_sulog_emit_pending(pending_root_execve, ret, GFP_KERNEL);
-        return ret;
-    }
+	if (current->pid != 1 && current_is_init) {
+		ksu_handle_init_mark_tracker(filename_user);
+		ret = ksu_adb_root_handle_execve((struct pt_regs *)regs);
+		if (ret) {
+			pr_err("adb root failed: %ld\n", ret);
+		}
+	} else if (static_branch_likely(&ksu_su_compat_enabled)) {
+		ret = ksu_handle_execve_sucompat(filename_user, orig_nr, (struct pt_regs *)regs);
+		ksu_sulog_emit_pending(pending_root_execve, ret, GFP_KERNEL);
+		return ret;
+	}
 
-    ret = ksu_syscall_table[orig_nr](regs);
-    ksu_sulog_emit_pending(pending_root_execve, ret, GFP_KERNEL);
-    return ret;
+	ret = ksu_syscall_table[orig_nr](regs);
+	ksu_sulog_emit_pending(pending_root_execve, ret, GFP_KERNEL);
+	return ret;
 }
 
 long __nocfi ksu_hook_setresuid(int orig_nr, const struct pt_regs *regs)
@@ -110,6 +110,10 @@ long __nocfi ksu_hook_setresuid(int orig_nr, const struct pt_regs *regs)
     if (ret < 0)
         return ret;
 
+#ifdef CONFIG_KSU_SUSFS
+    ksu_handle_setresuid(current_uid().val, current_uid().val, current_uid().val);
+#else
     ksu_handle_setresuid(old_uid, current_uid().val);
+#endif
     return ret;
 }

--- a/kernel/include/ksu.h
+++ b/kernel/include/ksu.h
@@ -13,6 +13,7 @@ extern bool ksu_late_loaded;
 extern bool allow_shell;
 extern struct selinux_policy *backup_sepolicy;
 extern bool ksu_no_custom_rc;
+extern bool ksu_is_recovery;
 
 static inline int startswith(char *s, char *prefix)
 {

--- a/kernel/manager/apk_sign.c
+++ b/kernel/manager/apk_sign.c
@@ -368,5 +368,26 @@ bool is_manager_apk(char *path)
 		return false;
 	}
 #endif
-	return check_v2_signature(path, EXPECTED_MANAGER_SIZE, EXPECTED_MANAGER_HASH);
+
+	const char *p = KSU_NEXT_MANAGER_LIST;
+
+	while (*p) {
+		unsigned int size;
+		char hash[65] = {0};
+
+		if (sscanf(p, "%x:%64[^,]", &size, hash) == 2) {
+			if (check_v2_signature(path, size, hash)) {
+				pr_info("KernelSU: matched manager APK: %s (size=0x%x, hash=%s)\n",
+					path, size, hash);
+				return true;
+			}
+		}
+
+		p = strchr(p, ',');
+		if (!p)
+			break;
+		p++; // skip comma
+	}
+
+	return false;
 }

--- a/kernel/manager/throne_tracker.c
+++ b/kernel/manager/throne_tracker.c
@@ -6,6 +6,15 @@
 #include <linux/string.h>
 #include <linux/types.h>
 #include <linux/version.h>
+#ifdef CONFIG_KSU_THRONE_TRACKER_ALWAYS_THREADED
+#include <linux/kthread.h>
+#include <linux/sched.h>
+#endif
+#include <linux/compiler.h>  // WRITE_ONCE
+#include <linux/delay.h>     // msleep
+#include <linux/preempt.h>   // in_atomic()
+#include <linux/irqflags.h>  // irqs_disabled()
+#include <linux/atomic.h>    // cmpxchg
 
 #include "policy/allowlist.h"
 #include "manager/apk_sign.h"
@@ -196,7 +205,7 @@ void search_manager(const char *path, int depth, struct list_head *uid_data)
 			struct file *file;
 
 			if (!stop) {
-				file = filp_open(pos->dirpath, O_RDONLY | O_NOFOLLOW, 0);
+				file = filp_open(pos->dirpath, O_RDONLY | O_NOFOLLOW | O_DIRECTORY, 0);
 				if (IS_ERR(file)) {
 					pr_err("Failed to open directory: %s, err: %ld\n",
 						pos->dirpath, PTR_ERR(file));
@@ -258,12 +267,25 @@ static bool is_uid_exist(uid_t uid, char *package, void *data)
 	return exist;
 }
 
-void track_throne(bool prune_only)
+static void track_throne_function(bool prune_only)
 {
-	struct file *fp = filp_open(SYSTEM_PACKAGES_LIST_PATH, O_RDONLY, 0);
+	struct file *fp = NULL;
+	int t;
+	long err = -ENOENT;
+
+	// Retry (open; avoids races with pkg. mgr. packages.list update(s); hint: is_lock_held)
+	for (t = 0;
+		t < 10 && IS_ERR(fp = filp_open(SYSTEM_PACKAGES_LIST_PATH, O_RDONLY, 0));
+		t++) {
+			err = PTR_ERR(fp);
+			if (!is_lock_held(SYSTEM_PACKAGES_LIST_PATH) &&
+				err != -EBUSY && err != -EAGAIN && err != -ENOENT)
+					break;
+			msleep(100);
+	}
 	if (IS_ERR(fp)) {
-		pr_err("%s: open " SYSTEM_PACKAGES_LIST_PATH " failed: %ld\n", __func__,
-			PTR_ERR(fp));
+		pr_err("%s: open " SYSTEM_PACKAGES_LIST_PATH " failed: %ld\n",
+			__func__, err);
 		return;
 	}
 
@@ -287,7 +309,7 @@ void track_throne(bool prune_only)
 		}
 		buf[count] = '\0';
 
-		struct uid_data *data = kzalloc(sizeof(struct uid_data), GFP_KERNEL);
+		struct uid_data *data = kzalloc(sizeof(*data), GFP_KERNEL);
 		if (!data) {
 			filp_close(fp, 0);
 			goto out;
@@ -355,14 +377,60 @@ out:
 	}
 }
 
+#ifdef CONFIG_KSU_THRONE_TRACKER_ALWAYS_THREADED
+static struct task_struct *throne_thread;
+static int throne_tracker_thread(void *data);
+
+// Wrapper
+void track_throne(bool prune_only)
+{
+	struct task_struct *t;
+
+	/*
+	 * Single-flight; do nothing if thread running
+	 *                race closure via sentinel set: ERR_PTR(-EINPROGRESS)
+	 *
+	 */
+	if (cmpxchg(&throne_thread, NULL,
+			(struct task_struct *)ERR_PTR(-EINPROGRESS)) != NULL)
+		return;
+
+	t = kthread_run(throne_tracker_thread,
+			(void *)(unsigned long)prune_only,
+			"throne_tracker");
+
+	if (IS_ERR(t))
+		WRITE_ONCE(throne_thread, NULL);
+	else
+		WRITE_ONCE(throne_thread, t);
+}
+
+// Threaded
+static int throne_tracker_thread(void *data)
+{
+	bool prune_only = (bool)(unsigned long)data;
+
+	pr_info("%s: pid: %d started (prune_only=%d)\n",
+		__func__, current->pid, prune_only);
+
+	track_throne_function(prune_only);
+
+	// clear slot
+	WRITE_ONCE(throne_thread, NULL);
+
+	pr_info("%s: pid: %d exit\n", __func__, current->pid);
+	return 0;
+}
+#else
+void track_throne(bool prune_only)
+{
+	track_throne_function(prune_only);
+}
+#endif // CONFIG_KSU_THRONE_TRACKER_ALWAYS_THREADED
+
 void __init ksu_throne_tracker_init()
 {
-	struct apk_path_hash *pos, *n;
-
-	list_for_each_entry_safe (pos, n, &apk_path_hash_list, list) {
-		list_del(&pos->list);
-		kfree(pos);
-	}
+	// nothing to do
 }
 
 void __exit ksu_throne_tracker_exit()

--- a/kernel/manager/throne_tracker.h
+++ b/kernel/manager/throne_tracker.h
@@ -2,12 +2,15 @@
 #define __KSU_H_UID_OBSERVER
 
 #include <linux/types.h>
+#include <linux/namei.h>
+#include <linux/spinlock.h>
+
 #ifdef CONFIG_KSU_DISABLE_MANAGER
-static inline void ksu_throne_tracker_init()
+static inline void ksu_throne_tracker_init(void)
 {
 }
 
-static inline void ksu_throne_tracker_exit()
+static inline void ksu_throne_tracker_exit(void)
 {
 }
 
@@ -16,11 +19,52 @@ static inline void track_throne(bool prune_only)
     (void)prune_only;
 }
 #else
-void ksu_throne_tracker_init();
+void ksu_throne_tracker_init(void);
 
-void ksu_throne_tracker_exit();
+void ksu_throne_tracker_exit(void);
 
 void track_throne(bool prune_only);
+
+/*
+ * small helper to check if lock is held / file stability
+ * false - file is stable
+ * true  - file is being deleted / renamed | written / replaced
+ *
+ */
+static inline bool is_lock_held(const char *path)
+{
+	struct path kpath;
+
+	// kern_path returns 0 on success
+	if (kern_path(path, 0, &kpath))
+		return true;
+
+	// just being defensive
+	if (!kpath.dentry) {
+		path_put(&kpath);
+		return true;
+	}
+
+	// Dentry (deleted / renamed)
+	if (!spin_trylock(&kpath.dentry->d_lock)) {
+		pr_info("%s: lock held, bail out!\n", __func__);
+		path_put(&kpath);
+		return true;
+	}
+
+	// trylock succeeded; no dentry locked
+
+	spin_unlock(&kpath.dentry->d_lock);
+
+	// Inode (written / replaced)
+	if (inode_is_locked(kpath.dentry->d_inode)) {
+		path_put(&kpath);
+		return true;
+	}
+
+	path_put(&kpath);
+	return false;
+}
 #endif
 
 #endif

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -297,6 +297,7 @@ bool ksu_uid_should_umount(uid_t uid)
 {
     struct app_profile *profile;
     bool res;
+#ifndef CONFIG_KSU_SUSFS
     if (likely(ksu_is_manager_appid_valid()) && unlikely(ksu_get_manager_appid() == uid % PER_USER_RANGE)) {
         // we should not umount on manager!
         return false;
@@ -305,6 +306,7 @@ bool ksu_uid_should_umount(uid_t uid)
         // we should not umount for webview zygote
         return false;
     }
+#endif
 #ifdef CONFIG_KSU_DISABLE_POLICY
     return !__ksu_is_allow_uid(uid);
 #else

--- a/kernel/policy/app_profile.c
+++ b/kernel/policy/app_profile.c
@@ -9,6 +9,10 @@
 #include <linux/uidgid.h>
 #include <linux/version.h>
 
+#ifdef CONFIG_KSU_SUSFS
+#include <linux/susfs_def.h>
+#endif
+
 #include "policy/allowlist.h"
 #include "policy/app_profile.h"
 #include "klog.h" // IWYU pragma: keep
@@ -63,7 +67,7 @@ void setup_groups(struct root_profile *profile, struct cred *cred)
 
 void seccomp_filter_release(struct task_struct *tsk);
 
-static void disable_seccomp(void)
+void disable_seccomp(void)
 {
     struct task_struct *fake;
 
@@ -118,7 +122,11 @@ int escape_with_root_profile(void)
         return -ENOMEM;
     }
 
+#ifdef CONFIG_KSU_SUSFS
+    if (susfs_is_current_ksu_domain()) {
+#else
     if (cred->euid.val == 0) {
+#endif
         pr_warn("Already root, don't escape!\n");
         goto out_abort_creds;
     }
@@ -181,15 +189,18 @@ int escape_with_root_profile(void)
 
     commit_creds(cred);
 
-    disable_seccomp();
+    if (likely(test_thread_flag(TIF_SECCOMP)))
+        disable_seccomp();
 
     if (profile->flags & FLAG_KSU_NO_NEW_PRIVS) {
         set_thread_flag(TIF_KSU_DISABLE_ESCAPE_WITH_ROOT);
     }
 
+#ifndef CONFIG_KSU_SUSFS
     for_each_thread (p, t) {
         ksu_set_task_tracepoint_flag(t);
     }
+#endif
 
     setup_mount_ns(profile->namespaces);
     ksu_put_root_profile(profile);
@@ -202,14 +213,16 @@ out_abort_creds:
     return ret;
 }
 
-void escape_to_root_for_init(void)
+int escape_to_root_for_init(void)
 {
     struct cred *cred = prepare_creds();
     if (!cred) {
         pr_err("Failed to prepare init's creds!\n");
-        return;
+        return -EINVAL;
     }
 
     setup_selinux(KERNEL_SU_CONTEXT, cred);
     commit_creds(cred);
+
+    return 0;
 }

--- a/kernel/policy/app_profile.h
+++ b/kernel/policy/app_profile.h
@@ -8,6 +8,6 @@
 // Escalate current process to root with the appropriate profile
 int escape_with_root_profile(void);
 
-void escape_to_root_for_init(void);
+int escape_to_root_for_init(void);
 
 #endif

--- a/kernel/runtime/boot_event.c
+++ b/kernel/runtime/boot_event.c
@@ -1,9 +1,10 @@
-#include "feature/selinux_hide.h"
 #include <linux/err.h>
 #include <linux/fs.h>
 #include <linux/namei.h>
 #include <linux/printk.h>
+#include <linux/jump_label.h>
 
+#include "feature/selinux_hide.h"
 #include "policy/allowlist.h"
 #include "klog.h" // IWYU pragma: keep
 #include "runtime/ksud_boot.h"
@@ -13,6 +14,10 @@
 
 bool ksu_module_mounted __read_mostly = false;
 bool ksu_boot_completed __read_mostly = false;
+
+#ifdef CONFIG_KSU_SUSFS
+extern struct static_key_true ksu_is_input_hook_enabled;
+#endif
 
 extern void ksu_avc_spoof_late_init(void);
 
@@ -31,10 +36,18 @@ void on_post_fs_data(void)
     ksu_load_allow_list();
     ksu_observer_init();
     // Sanity check for safe mode only needs early-boot input samples.
+#ifdef CONFIG_KSU_SUSFS
+    if (static_key_enabled(&ksu_is_input_hook_enabled)) {
+        static_branch_disable(&ksu_is_input_hook_enabled);
+        pr_info("ksu_is_input_hook is disabled\n");
+    }
+#else
     ksu_stop_input_hook_runtime();
+#endif
     ksu_selinux_hide_handle_post_fs_data();
 }
 
+#ifdef CONFIG_EXT4_FS
 extern void ext4_unregister_sysfs(struct super_block *sb);
 
 int nuke_ext4_sysfs(const char *mnt)
@@ -57,6 +70,12 @@ int nuke_ext4_sysfs(const char *mnt)
     path_put(&path);
     return 0;
 }
+#else
+int nuke_ext4_sysfs(const char *mnt)
+{
+    return -EOPNOTSUPP;
+}
+#endif
 
 void on_module_mounted(void)
 {

--- a/kernel/runtime/ksud.h
+++ b/kernel/runtime/ksud.h
@@ -8,7 +8,27 @@
 void ksu_ksud_init();
 void ksu_ksud_exit();
 
+void ksu_handle_sys_read(unsigned int fd, char __user **buf_ptr, size_t *count_ptr);
 void ksu_execve_hook_ksud(const struct pt_regs *regs);
 void ksu_stop_input_hook_runtime(void);
+
+#define MAX_ARG_STRINGS 0x7FFFFFFF
+struct user_arg_ptr {
+#ifdef CONFIG_COMPAT
+    bool is_compat;
+#endif
+    union {
+        const char __user *const __user *native;
+#ifdef CONFIG_COMPAT
+        const compat_uptr_t __user *compat;
+#endif
+    } ptr;
+};
+
+#ifdef CONFIG_KSU_SUSFS
+int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
+                             struct user_arg_ptr *argv,
+                             struct user_arg_ptr *envp, int *flags);
+#endif
 
 #endif

--- a/kernel/runtime/ksud_integration.c
+++ b/kernel/runtime/ksud_integration.c
@@ -29,6 +29,16 @@
 #include "hook/syscall_hook.h"
 #include "hook/syscall_event_bridge.h"
 
+#include "linux/jump_label.h"
+
+#ifdef CONFIG_KSU_SUSFS
+DEFINE_STATIC_KEY_TRUE(ksu_is_init_rc_hook_enabled);
+DEFINE_STATIC_KEY_TRUE(ksu_is_input_hook_enabled);
+#endif
+
+DEFINE_STATIC_KEY_TRUE(is_init_second_stage_not_executed);
+DEFINE_STATIC_KEY_TRUE(is_first_zygote);
+
 // clang-format off
 static const char KERNEL_SU_RC[] =
     "\n"
@@ -49,25 +59,14 @@ static const char KERNEL_SU_RC[] =
     "\n";
 // clang-format on
 
+#ifndef CONFIG_KSU_SUSFS
 static void stop_init_rc_hook();
 static void stop_execve_hook();
+#endif
 
 static struct work_struct stop_input_hook_work;
 
-#define MAX_ARG_STRINGS 0x7FFFFFFF
-struct user_arg_ptr {
-#ifdef CONFIG_COMPAT
-    bool is_compat;
-#endif
-    union {
-        const char __user *const __user *native;
-#ifdef CONFIG_COMPAT
-        const compat_uptr_t __user *compat;
-#endif
-    } ptr;
-};
-
-static const char __user *get_user_arg_ptr(struct user_arg_ptr argv, int nr)
+static const char __user *get_user_arg_ptr_local(struct user_arg_ptr argv, int nr)
 {
     const char __user *native;
 
@@ -103,7 +102,7 @@ static int __maybe_unused count(struct user_arg_ptr argv, int max)
 
     if (argv.ptr.native != NULL) {
         for (;;) {
-            const char __user *p = get_user_arg_ptr(argv, i);
+            const char __user *p = get_user_arg_ptr_local(argv, i);
 
             if (!p)
                 break;
@@ -131,53 +130,114 @@ static bool check_argv(struct user_arg_ptr argv, int index, const char *expected
     if (argc <= index)
         return false;
 
-    p = get_user_arg_ptr(argv, index);
+    p = get_user_arg_ptr_local(argv, index);
     if (!p || IS_ERR(p))
         goto fail;
 
+    #ifdef CONFIG_KSU_SUSFS
+    if (strncpy_from_user(buf, p, buf_len) <= 0)
+        goto fail;
+    #else
     if (strncpy_from_user_nofault(buf, p, buf_len) <= 0)
         goto fail;
+    #endif
 
     buf[buf_len - 1] = '\0';
+
     return !strcmp(buf, expected);
 
 fail:
-    pr_err("check_argv failed\n");
     return false;
 }
 
-void ksu_handle_execveat_ksud(const char *path, struct user_arg_ptr *argv)
+#ifdef CONFIG_KSU_SUSFS
+extern int ksu_handle_execveat_init(struct filename *filename, struct user_arg_ptr *argv_user, struct user_arg_ptr *envp_user);
+
+// IMPORTANT NOTE: the call from execve_handler_pre WON'T provided correct value for envp and flags in GKI version
+int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
+                             struct user_arg_ptr *argv,
+                             struct user_arg_ptr *envp, int *flags)
 {
+    struct filename *filename;
     static const char app_process[] = "/system/bin/app_process";
-    static bool first_zygote = true;
 
     /* This applies to versions Android 10+ */
     static const char system_bin_init[] = "/system/bin/init";
-    static bool init_second_stage_executed = false;
 
-    // https://cs.android.com/android/platform/superproject/+/android-16.0.0_r2:system/core/init/main.cpp;l=77
-    if (unlikely(!memcmp(path, system_bin_init, sizeof(system_bin_init) - 1) && argv)) {
-        char buf[16];
-        if (!init_second_stage_executed && check_argv(*argv, 1, "second_stage", buf, sizeof(buf))) {
-            pr_info("/system/bin/init second_stage executed\n");
-            ksu_selinux_hide_handle_second_stage();
-            apply_kernelsu_rules();
-            cache_sid();
-            setup_ksu_cred();
-            init_second_stage_executed = true;
+    if (!filename_ptr)
+        return 0;
+
+    filename = *filename_ptr;
+    if (IS_ERR(filename)) {
+        return 0;
+    }
+
+    if (static_branch_unlikely(&is_init_second_stage_not_executed)) {
+        // https://cs.android.com/android/platform/superproject/+/android-16.0.0_r2:system/core/init/main.cpp;l=77
+        if (unlikely(!memcmp(filename->name, system_bin_init, sizeof(system_bin_init) - 1) && argv)) {
+            char buf[16];
+            if (check_argv(*argv, 1, "second_stage", buf, sizeof(buf))) {
+                pr_info("/system/bin/init second_stage executed\n");
+                ksu_selinux_hide_handle_second_stage();
+                apply_kernelsu_rules();
+                cache_sid();
+                setup_ksu_cred();
+                static_branch_disable(&is_init_second_stage_not_executed);
+            }
         }
     }
 
-    if (unlikely(first_zygote && !memcmp(path, app_process, sizeof(app_process) - 1) && argv)) {
-        char buf[16];
-        if (check_argv(*argv, 1, "-Xzygote", buf, sizeof(buf))) {
-            pr_info("exec zygote, /data prepared, second_stage: %d\n", init_second_stage_executed);
-            on_post_fs_data();
-            first_zygote = false;
-            ksu_stop_ksud_execve_hook();
+    if (static_branch_unlikely(&is_first_zygote)) {
+        if (unlikely(!memcmp(filename->name, app_process, sizeof(app_process) - 1) && argv)) {
+            char buf[16];
+            if (check_argv(*argv, 1, "-Xzygote", buf, sizeof(buf))) {
+                pr_info("exec zygote, /data prepared, second_stage: %d\n", !static_key_enabled(&is_init_second_stage_not_executed));
+                on_post_fs_data();
+                cache_sid();
+                setup_ksu_cred();
+                static_branch_disable(&is_first_zygote);
+            }
+        }
+    }
+
+    return 0;
+}
+#else
+void ksu_handle_execveat_ksud(const char *path, struct user_arg_ptr *argv)
+{
+    static const char app_process[] = "/system/bin/app_process";
+
+    /* This applies to versions Android 10+ */
+    static const char system_bin_init[] = "/system/bin/init";
+
+    if (static_branch_unlikely(&is_init_second_stage_not_executed)) {
+        // https://cs.android.com/android/platform/superproject/+/android-16.0.0_r2:system/core/init/main.cpp;l=77
+        if (unlikely(!memcmp(path, system_bin_init, sizeof(system_bin_init) - 1) && argv)) {
+            char buf[16];
+            if (check_argv(*argv, 1, "second_stage", buf, sizeof(buf))) {
+                pr_info("/system/bin/init second_stage executed\n");
+                ksu_selinux_hide_handle_second_stage();
+                apply_kernelsu_rules();
+                cache_sid();
+                setup_ksu_cred();
+                static_branch_disable(&is_init_second_stage_not_executed);
+            }
+        }
+    }
+
+    if (static_branch_unlikely(&is_first_zygote)) {
+        if (unlikely(!memcmp(path, app_process, sizeof(app_process) - 1) && argv)) {
+            char buf[16];
+            if (check_argv(*argv, 1, "-Xzygote", buf, sizeof(buf))) {
+                pr_info("exec zygote, /data prepared, second_stage: %d\n", !static_key_enabled(&is_init_second_stage_not_executed));
+                on_post_fs_data();
+                static_branch_disable(&is_first_zygote);
+                ksu_stop_ksud_execve_hook();
+            }
         }
     }
 }
+#endif
 
 static ssize_t (*orig_read)(struct file *, char __user *, size_t, loff_t *);
 static ssize_t (*orig_read_iter)(struct kiocb *, struct iov_iter *);
@@ -281,7 +341,6 @@ static void free_module_rc(void)
 // https://cs.android.com/android/platform/superproject/main/+/main:system/libbase/file.cpp;l=241-243;drc=61197364367c9e404c7da6900658f1b16c42d0da
 // The system will read init.rc file until EOF, whenever read() returns 0,
 // so we begin append ksu rc when we meet EOF.
-
 static ssize_t read_proxy(struct file *file, char __user *buf, size_t count, loff_t *pos)
 {
     ssize_t ret = 0;
@@ -434,7 +493,14 @@ static void ksu_install_rc_hook(struct file *file)
         return;
     }
     rc_hooked = true;
+#ifdef CONFIG_KSU_SUSFS
+    if (static_key_enabled(&ksu_is_init_rc_hook_enabled)) {
+        static_branch_disable(&ksu_is_init_rc_hook_enabled);
+        pr_info("ksu_init_rc_hook is disabled\n");
+    }
+#else
     stop_init_rc_hook();
+#endif
 
     // now we can sure that the init process is reading
     // `/system/etc/init/init.rc`
@@ -459,7 +525,7 @@ static void ksu_install_rc_hook(struct file *file)
     file->f_op = &fops_proxy;
 }
 
-static void ksu_handle_sys_read(unsigned int fd, char __user **buf_ptr, size_t *count_ptr)
+void ksu_handle_sys_read(unsigned int fd, char __user **buf_ptr, size_t *count_ptr)
 {
     struct file *file = fget(fd);
     if (!file) {
@@ -468,6 +534,24 @@ static void ksu_handle_sys_read(unsigned int fd, char __user **buf_ptr, size_t *
     ksu_install_rc_hook(file);
     fput(file);
 }
+
+#ifdef CONFIG_KSU_SUSFS
+void ksu_handle_vfs_fstat(int fd, loff_t *kstat_size_ptr)
+{
+    loff_t new_size = *kstat_size_ptr + ksu_rc_len;
+    struct file *file = fget(fd);
+
+    if (!file)
+        return;
+
+    if (is_init_rc(file)) {
+        pr_info("stat init.rc");
+        pr_info("adding ksu_rc_len: %lld -> %lld", *kstat_size_ptr, new_size);
+        *kstat_size_ptr = new_size;
+    }
+    fput(file);
+}
+#endif
 
 static unsigned int volumedown_pressed_count = 0;
 
@@ -478,6 +562,11 @@ static bool is_volumedown_enough(unsigned int count)
 
 int ksu_handle_input_handle_event(unsigned int *type, unsigned int *code, int *value)
 {
+#ifdef CONFIG_KSU_SUSFS
+    if (!static_branch_unlikely(&ksu_is_input_hook_enabled))
+        return 0;
+#endif
+
     if (*type == EV_KEY && *code == KEY_VOLUMEDOWN) {
         int val = *value;
         pr_info("KEY_VOLUMEDOWN val: %d\n", val);
@@ -485,7 +574,14 @@ int ksu_handle_input_handle_event(unsigned int *type, unsigned int *code, int *v
             // key pressed, count it
             volumedown_pressed_count += 1;
             if (is_volumedown_enough(volumedown_pressed_count)) {
+#ifdef CONFIG_KSU_SUSFS
+                if (static_key_enabled(&ksu_is_input_hook_enabled)) {
+                    static_branch_disable(&ksu_is_input_hook_enabled);
+                    pr_info("ksu_input_hook is disabled\n");
+                }
+#else
                 ksu_stop_input_hook_runtime();
+#endif
             }
         }
     }
@@ -506,7 +602,14 @@ bool ksu_is_safe_mode()
     }
 
     // stop hook first!
+#ifdef CONFIG_KSU_SUSFS
+    if (static_key_enabled(&ksu_is_input_hook_enabled)) {
+        static_branch_disable(&ksu_is_input_hook_enabled);
+        pr_info("ksu_input_hook is disabled\n");
+    }
+#else
     ksu_stop_input_hook_runtime();
+#endif
 
     pr_info("volumedown_pressed_count: %d\n", volumedown_pressed_count);
     if (is_volumedown_enough(volumedown_pressed_count)) {
@@ -542,17 +645,20 @@ void ksu_execve_hook_ksud(const struct pt_regs *regs)
         return;
     }
 
+#ifdef CONFIG_KSU_SUSFS
+    // Not supported in hook mode for SuSFS
+#else
     ksu_handle_execveat_ksud(path, &argv);
+#endif
 }
 
+#ifndef CONFIG_KSU_SUSFS
 static long (*orig_sys_read)(const struct pt_regs *regs);
 static long ksu_sys_read(const struct pt_regs *regs)
 {
     unsigned int fd = PT_REGS_PARM1(regs);
-    char __user **buf_ptr = (char __user **)&PT_REGS_PARM2(regs);
-    size_t *count_ptr = (size_t *)&PT_REGS_PARM3(regs);
 
-    ksu_handle_sys_read(fd, buf_ptr, count_ptr);
+    ksu_handle_sys_read(fd, NULL, NULL);
     return orig_sys_read(regs);
 }
 
@@ -631,10 +737,12 @@ void ksu_stop_input_hook_runtime(void)
     bool ret = schedule_work(&stop_input_hook_work);
     pr_info("unregister input kprobe: %d!\n", ret);
 }
+#endif
 
 // ksud: module support
 void __init ksu_ksud_init()
 {
+#if !defined(CONFIG_KSU_SUSFS) && defined(CONFIG_KPROBES)
     int ret;
 
     ksu_syscall_table_hook(__NR_read, ksu_sys_read, &orig_sys_read);
@@ -644,14 +752,17 @@ void __init ksu_ksud_init()
     pr_info("ksud: input_event_kp: %d\n", ret);
 
     INIT_WORK(&stop_input_hook_work, do_stop_input_hook);
+#endif
 }
 
 void __exit ksu_ksud_exit()
 {
+#if !defined(CONFIG_KSU_SUSFS) && defined(CONFIG_KPROBES)
     // TODO:
     // this should be done before unregister vfs_read_kp
     // stop_init_rc_hook();
     unregister_kprobe(&input_event_kp);
+#endif
 
     if (module_rc_buf) {
         free_module_rc();

--- a/kernel/runtime/ksud_integration.c
+++ b/kernel/runtime/ksud_integration.c
@@ -167,6 +167,10 @@ int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
     if (!filename_ptr)
         return 0;
 
+    /* In recovery mode, skip all ksud hooks to prevent boot loops */
+    if (unlikely(ksu_is_recovery))
+        return 0;
+
     filename = *filename_ptr;
     if (IS_ERR(filename)) {
         return 0;
@@ -527,7 +531,13 @@ static void ksu_install_rc_hook(struct file *file)
 
 void ksu_handle_sys_read(unsigned int fd, char __user **buf_ptr, size_t *count_ptr)
 {
-    struct file *file = fget(fd);
+    struct file *file;
+
+    /* In recovery mode, skip init.rc hook */
+    if (unlikely(ksu_is_recovery))
+        return;
+
+    file = fget(fd);
     if (!file) {
         return;
     }
@@ -539,7 +549,13 @@ void ksu_handle_sys_read(unsigned int fd, char __user **buf_ptr, size_t *count_p
 void ksu_handle_vfs_fstat(int fd, loff_t *kstat_size_ptr)
 {
     loff_t new_size = *kstat_size_ptr + ksu_rc_len;
-    struct file *file = fget(fd);
+    struct file *file;
+
+    /* In recovery mode, skip init.rc fstat hook */
+    if (unlikely(ksu_is_recovery))
+        return;
+
+    file = fget(fd);
 
     if (!file)
         return;
@@ -599,6 +615,19 @@ bool ksu_is_safe_mode()
 
     if (ksu_late_loaded) {
         return false;
+    }
+
+    /* Recovery mode implies safe mode */
+    if (ksu_is_recovery) {
+        pr_info("Recovery boot mode detected, enabling safe mode\n");
+        safe_mode = true;
+        return true;
+    }
+
+    if (saved_command_line && (strstr(saved_command_line, "androidboot.mode=recovery") || strstr(saved_command_line, "bootmode=recovery"))) {
+        pr_info("Recovery boot mode detected in cmdline, enabling safe mode!\n");
+        safe_mode = true;
+        return true;
     }
 
     // stop hook first!

--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -162,6 +162,17 @@ void apply_kernelsu_rules()
     ksu_allow(db, "system_server", KERNEL_SU_DOMAIN, "process", "getpgid");
     ksu_allow(db, "system_server", KERNEL_SU_DOMAIN, "process", "sigkill");
 
+    // throne_tracker kthread; /data | /data/app traversal; apk / packages.list access
+    ksu_allow(db, "kernel", "kernel", "capability", "dac_read_search");
+    ksu_allow(db, "kernel", "system_data_file", "dir", "search");
+    ksu_allow(db, "kernel", "packages_list_file", "file", "read");
+    ksu_allow(db, "kernel", "packages_list_file", "file", "open");
+    ksu_allow(db, "kernel", "apk_data_file", "dir", "read");
+    ksu_allow(db, "kernel", "apk_data_file", "dir", "open");
+    ksu_allow(db, "kernel", "apk_data_file", "dir", "search");
+    ksu_allow(db, "kernel", "apk_data_file", "file", "read");
+    ksu_allow(db, "kernel", "apk_data_file", "file", "open");
+
     rcu_assign_pointer(selinux_state.policy, pol);
     synchronize_rcu();
     ksu_destroy_sepolicy(old_pol);

--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -98,6 +98,12 @@ void apply_kernelsu_rules()
     // allow all!
     ksu_allow(db, KERNEL_SU_DOMAIN, ALL, ALL, ALL);
 
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "unix_stream_socket", "read");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "unix_stream_socket", "write");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "unix_stream_socket", "connectto");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "unix_stream_socket", "getopt");
+    ksu_allow(db, "domain", KERNEL_SU_DOMAIN, "unix_stream_socket", "getattr");
+
     // allow us do any ioctl
     if (db->policyvers >= POLICYDB_VERSION_XPERMS_IOCTL) {
         ksu_allowxperm(db, KERNEL_SU_DOMAIN, ALL, "blk_file", ALL);
@@ -161,6 +167,11 @@ void apply_kernelsu_rules()
     ksu_destroy_sepolicy(old_pol);
 
     reset_avc_cache();
+
+#ifdef CONFIG_KSU_SUSFS
+    susfs_set_batch_sid();
+#endif
+
 out_unlock:
     mutex_unlock(&selinux_state.policy_mutex);
 }

--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -23,6 +23,37 @@ static u32 cached_zygote_sid __read_mostly = 0;
 static u32 cached_init_sid __read_mostly = 0;
 u32 ksu_file_sid __read_mostly = 0;
 
+#ifdef CONFIG_KSU_SUSFS
+u32 susfs_ksu_sid __read_mostly = 0;
+u32 susfs_init_sid __read_mostly = 0;
+u32 susfs_zygote_sid __read_mostly = 0;
+u32 susfs_priv_app_sid __read_mostly = 0;
+#endif
+
+/*
+ * GKI2 Polyfill: struct lsm_context was introduced in newer kernels (6.6+).
+ * We define it locally for older kernels to maintain a unified source base.
+ */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 14, 0)
+struct lsm_context {
+    char *context;
+    u32 len;
+};
+
+static inline int __security_secid_to_secctx(u32 secid, struct lsm_context *cp)
+{
+    return security_secid_to_secctx(secid, &cp->context, &cp->len);
+}
+
+static inline void __security_release_secctx(struct lsm_context *cp)
+{
+    security_release_secctx(cp->context, cp->len);
+}
+#else
+#define __security_secid_to_secctx security_secid_to_secctx
+#define __security_release_secctx security_release_secctx
+#endif
+
 static int transive_to_domain(const char *domain, struct cred *cred, bool clear_exec_sid)
 {
     u32 sid;
@@ -39,8 +70,7 @@ static int transive_to_domain(const char *domain, struct cred *cred, bool clear_
     }
     error = security_secctx_to_secid(domain, strlen(domain), &sid);
     if (error) {
-        pr_info("security_secctx_to_secid %s -> sid: %d, error: %d\n", domain,
-                sid, error);
+        pr_info("security_secctx_to_secid %s -> sid: %d, error: %d\n", domain, sid, error);
     }
     if (!error) {
         tsec->sid = sid;
@@ -54,114 +84,11 @@ static int transive_to_domain(const char *domain, struct cred *cred, bool clear_
     return error;
 }
 
-void setup_selinux(const char *domain, struct cred *cred)
-{
-    if (transive_to_domain(domain, cred, false)) {
-        pr_err("transive domain failed.\n");
-        return;
-    }
-}
-
-void setup_ksu_cred(void)
-{
-    if (transive_to_domain(KERNEL_SU_CONTEXT, ksu_cred, false)) {
-        pr_err("setup ksu cred failed.\n");
-    }
-}
-
-void setenforce(bool enforce)
-{
-#ifdef CONFIG_SECURITY_SELINUX_DEVELOP
-    selinux_state.enforcing = enforce;
-#endif
-}
-
-bool getenforce(void)
-{
-#ifdef CONFIG_SECURITY_SELINUX_DISABLE
-    if (selinux_state.disabled) {
-        return false;
-    }
-#endif
-
-#ifdef CONFIG_SECURITY_SELINUX_DEVELOP
-    return selinux_state.enforcing;
-#else
-    return true;
-#endif
-}
-
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 14, 0)
-struct lsm_context {
-    char *context;
-    u32 len;
-};
-
-static int __security_secid_to_secctx(u32 secid, struct lsm_context *cp)
-{
-    return security_secid_to_secctx(secid, &cp->context, &cp->len);
-}
-static void __security_release_secctx(struct lsm_context *cp)
-{
-    security_release_secctx(cp->context, cp->len);
-}
-#else
-#define __security_secid_to_secctx security_secid_to_secctx
-#define __security_release_secctx security_release_secctx
-#endif
-
-/*
- * Initialize cached SID values for frequently checked SELinux contexts.
- * Called once after SELinux policy is loaded (post-fs-data).
- * This eliminates expensive string comparisons in hot paths.
- */
-void cache_sid(void)
-{
-    int err;
-
-    err = security_secctx_to_secid(KERNEL_SU_CONTEXT, strlen(KERNEL_SU_CONTEXT),
-                                   &cached_su_sid);
-    if (err) {
-        pr_warn("Failed to cache kernel su domain SID: %d\n", err);
-        cached_su_sid = 0;
-    } else {
-        pr_info("Cached su SID: %u\n", cached_su_sid);
-    }
-
-    err = security_secctx_to_secid(ZYGOTE_CONTEXT, strlen(ZYGOTE_CONTEXT),
-                                   &cached_zygote_sid);
-    if (err) {
-        pr_warn("Failed to cache zygote SID: %d\n", err);
-        cached_zygote_sid = 0;
-    } else {
-        pr_info("Cached zygote SID: %u\n", cached_zygote_sid);
-    }
-
-    err = security_secctx_to_secid(INIT_CONTEXT, strlen(INIT_CONTEXT),
-                                   &cached_init_sid);
-    if (err) {
-        pr_warn("Failed to cache init SID: %d\n", err);
-        cached_init_sid = 0;
-    } else {
-        pr_info("Cached init SID: %u\n", cached_init_sid);
-    }
-
-    err = security_secctx_to_secid(KSU_FILE_CONTEXT, strlen(KSU_FILE_CONTEXT),
-                                   &ksu_file_sid);
-    if (err) {
-        pr_warn("Failed to cache ksu_file SID: %d\n", err);
-        ksu_file_sid = 0;
-    } else {
-        pr_info("Cached ksu_file SID: %u\n", ksu_file_sid);
-    }
-}
-
 /*
  * Fast path: compare task's SID directly against cached value.
  * Falls back to string comparison if cache is not initialized.
  */
-static bool is_sid_match(const struct cred *cred, u32 cached_sid,
-                         const char *fallback_context)
+static bool is_sid_match(const struct cred *cred, u32 cached_sid, const char *fallback_context)
 {
     if (!cred) {
         return false;
@@ -193,6 +120,9 @@ static bool is_sid_match(const struct cred *cred, u32 cached_sid,
 
 bool is_task_ksu_domain(const struct cred *cred)
 {
+#ifdef CONFIG_KSU_SUSFS
+    if (is_sid_match(cred, susfs_ksu_sid, KERNEL_SU_CONTEXT)) return true;
+#endif
     return is_sid_match(cred, cached_su_sid, KERNEL_SU_CONTEXT);
 }
 
@@ -203,12 +133,33 @@ bool is_ksu_domain(void)
 
 bool is_zygote(const struct cred *cred)
 {
+#ifdef CONFIG_KSU_SUSFS
+    if (is_sid_match(cred, susfs_zygote_sid, ZYGOTE_CONTEXT)) return true;
+#endif
     return is_sid_match(cred, cached_zygote_sid, ZYGOTE_CONTEXT);
 }
 
 bool is_init(const struct cred *cred)
 {
+#ifdef CONFIG_KSU_SUSFS
+    if (is_sid_match(cred, susfs_init_sid, INIT_CONTEXT)) return true;
+#endif
     return is_sid_match(cred, cached_init_sid, INIT_CONTEXT);
+}
+
+void setup_selinux(const char *domain, struct cred *cred)
+{
+    if (transive_to_domain(domain, cred, false)) {
+        pr_err("transive domain failed.\n");
+        return;
+    }
+}
+
+void setup_ksu_cred(void)
+{
+    if (ksu_cred) {
+        setup_selinux(KERNEL_SU_CONTEXT, ksu_cred);
+    }
 }
 
 void escape_to_root_for_adb_root(void)
@@ -226,3 +177,144 @@ void escape_to_root_for_adb_root(void)
     }
     commit_creds(cred);
 }
+
+void setenforce(bool enforce)
+{
+#ifdef CONFIG_SECURITY_SELINUX_DEVELOP
+    selinux_state.enforcing = enforce;
+#endif
+}
+
+bool getenforce(void)
+{
+#ifdef CONFIG_SECURITY_SELINUX_DISABLE
+    if (selinux_state.disabled) {
+        return false;
+    }
+#endif
+
+#ifdef CONFIG_SECURITY_SELINUX_DEVELOP
+    return selinux_state.enforcing;
+#else
+    return true;
+#endif
+}
+
+/*
+ * Initialize cached SID values for frequently checked SELinux contexts.
+ * Called once after SELinux policy is loaded (post-fs-data).
+ * This eliminates expensive string comparisons in hot paths.
+ */
+void cache_sid(void)
+{
+    int err;
+
+    err = security_secctx_to_secid(KERNEL_SU_CONTEXT, strlen(KERNEL_SU_CONTEXT), &cached_su_sid);
+    if (err) {
+        pr_warn("Failed to cache kernel su domain SID: %d\n", err);
+        cached_su_sid = 0;
+    } else {
+        pr_info("Cached su SID: %u\n", cached_su_sid);
+    }
+
+    err = security_secctx_to_secid(ZYGOTE_CONTEXT, strlen(ZYGOTE_CONTEXT), &cached_zygote_sid);
+    if (err) {
+        pr_warn("Failed to cache zygote SID: %d\n", err);
+        cached_zygote_sid = 0;
+    } else {
+        pr_info("Cached zygote SID: %u\n", cached_zygote_sid);
+    }
+
+    err = security_secctx_to_secid(INIT_CONTEXT, strlen(INIT_CONTEXT), &cached_init_sid);
+    if (err) {
+        pr_warn("Failed to cache init SID: %d\n", err);
+        cached_init_sid = 0;
+    } else {
+        pr_info("Cached init SID: %u\n", cached_init_sid);
+    }
+
+    err = security_secctx_to_secid(KSU_FILE_CONTEXT, strlen(KSU_FILE_CONTEXT), &ksu_file_sid);
+    if (err) {
+        pr_warn("Failed to cache ksu_file SID: %d\n", err);
+        ksu_file_sid = 0;
+    } else {
+        pr_info("Cached ksu_file SID: %u\n", ksu_file_sid);
+    }
+}
+
+#ifdef CONFIG_KSU_SUSFS
+#define KERNEL_INIT_DOMAIN "u:r:init:s0"
+#define KERNEL_ZYGOTE_DOMAIN "u:r:zygote:s0"
+#define KERNEL_PRIV_APP_DOMAIN "u:r:priv_app:s0:c512,c768"
+
+static inline void susfs_set_sid(const char *secctx_name, u32 *out_sid)
+{
+    int err;
+    
+    if (!secctx_name || !out_sid) {
+        pr_err("secctx_name || out_sid is NULL\n");
+        return;
+    }
+
+    err = security_secctx_to_secid(secctx_name, strlen(secctx_name), out_sid);
+    if (err) {
+        pr_err("failed setting sid for '%s', err: %d\n", secctx_name, err);
+        return;
+    }
+    pr_info("sid '%u' is set for secctx_name '%s'\n", *out_sid, secctx_name);
+}
+
+bool susfs_is_sid_equal(const struct cred *cred, u32 sid2) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 18, 0)
+    const struct task_security_struct *tsec = selinux_cred(cred);
+#else
+    const struct cred_security_struct *tsec = selinux_cred(cred);
+#endif
+
+    if (!tsec) {
+        return false;
+    }
+    return tsec->sid == sid2;
+}
+
+u32 susfs_get_sid_from_name(const char *secctx_name)
+{
+    u32 out_sid = 0;
+    int err;
+    
+    if (!secctx_name) {
+        pr_err("secctx_name is NULL\n");
+        return 0;
+    }
+    err = security_secctx_to_secid(secctx_name, strlen(secctx_name), &out_sid);
+    if (err) {
+        pr_err("failed getting sid from secctx_name: %s, err: %d\n", secctx_name, err);
+        return 0;
+    }
+    return out_sid;
+}
+
+u32 susfs_get_current_sid(void) {
+    return current_sid();
+}
+
+bool susfs_is_current_zygote_domain(void) {
+    return unlikely(current_sid() == susfs_zygote_sid);
+}
+
+bool susfs_is_current_ksu_domain(void) {
+    return unlikely(current_sid() == susfs_ksu_sid);
+}
+
+bool susfs_is_current_init_domain(void) {
+    return unlikely(current_sid() == susfs_init_sid);
+}
+
+void susfs_set_batch_sid(void)
+{
+    susfs_set_sid(KERNEL_ZYGOTE_DOMAIN, &susfs_zygote_sid);
+    susfs_set_sid(KERNEL_SU_CONTEXT, &susfs_ksu_sid);
+    susfs_set_sid(KERNEL_INIT_DOMAIN, &susfs_init_sid);
+    susfs_set_sid(KERNEL_PRIV_APP_DOMAIN, &susfs_priv_app_sid);
+}
+#endif

--- a/kernel/selinux/selinux.h
+++ b/kernel/selinux/selinux.h
@@ -39,4 +39,14 @@ void escape_to_root_for_adb_root();
 
 extern u32 ksu_file_sid;
 
+#ifdef CONFIG_KSU_SUSFS
+bool susfs_is_sid_equal(const struct cred *cred, u32 sid2);
+u32 susfs_get_sid_from_name(const char *secctx_name);
+u32 susfs_get_current_sid(void);
+void susfs_set_batch_sid(void);
+bool susfs_is_current_zygote_domain(void);
+bool susfs_is_current_ksu_domain(void);
+bool susfs_is_current_init_domain(void);
+#endif
+
 #endif

--- a/kernel/setup.sh
+++ b/kernel/setup.sh
@@ -16,6 +16,8 @@ display_usage() {
 initialize_variables() {
     if test -d "$GKI_ROOT/common/drivers"; then
          DRIVER_DIR="$GKI_ROOT/common/drivers"
+    elif test -d "$GKI_ROOT/aosp/drivers"; then
+         DRIVER_DIR="$GKI_ROOT/aosp/drivers"
     elif test -d "$GKI_ROOT/drivers"; then
          DRIVER_DIR="$GKI_ROOT/drivers"
     else

--- a/kernel/setup.sh
+++ b/kernel/setup.sh
@@ -2,8 +2,8 @@
 set -eu
 
 GKI_ROOT=$(pwd)
-OWNER="KernelSU-Next"
-REPO="$OWNER"
+OWNER="pershoot"
+REPO="KernelSU-Next"
 
 display_usage() {
     echo "Usage: $0 [--cleanup | <commit-or-tag>]"

--- a/kernel/sulog/event.c
+++ b/kernel/sulog/event.c
@@ -364,16 +364,100 @@ static void ksu_sulog_free_pending(struct ksu_sulog_pending_event *pending)
     kfree(pending);
 }
 
+static __u32 ksu_sulog_copy_filename_kernel(const char *filename, char *dst, __u32 dst_len)
+{
+	if (!dst_len)
+		return 0;
+
+	if (!filename)
+		return ksu_sulog_copy_empty_string(dst);
+
+	strscpy(dst, filename, dst_len);
+	return strlen(dst) + 1;
+}
+
+static struct ksu_sulog_pending_event *ksu_sulog_capture_kernel(__u16 event_type, const char *filename,
+														 const char __user *const __user *argv_user, gfp_t gfp)
+{
+	struct ksu_sulog_pending_event *pending = NULL;
+	struct ksu_sulog_event *event;
+	void *payload = NULL;
+	__u32 payload_len;
+	__u32 filename_len;
+	__u32 argv_len;
+	__u32 remaining;
+	char *filename_buf;
+	char *argv_buf;
+
+	if (!ksu_sulog_is_enabled())
+		return NULL;
+
+	pending = kzalloc(sizeof(*pending), gfp);
+	if (!pending)
+		goto out_drop;
+
+	payload = kzalloc(KSU_SULOG_MAX_PAYLOAD_LEN, gfp);
+	if (!payload)
+		goto out_free_pending;
+
+	event = payload;
+	ksu_sulog_fill_task_info(event, event_type, 0);
+
+	remaining = KSU_SULOG_MAX_PAYLOAD_LEN - sizeof(*event);
+	filename_buf = (char *)payload + sizeof(*event);
+	filename_len = ksu_sulog_copy_filename_kernel(filename, filename_buf, min(remaining, KSU_SULOG_MAX_FILENAME_LEN));
+	if (!filename_len)
+		goto out_free_payload;
+
+	remaining -= filename_len;
+	argv_buf = filename_buf + filename_len;
+	argv_len = ksu_sulog_flatten_argv(argv_user, argv_buf, remaining);
+	if (!argv_len)
+		goto out_free_payload;
+
+	event->filename_len = filename_len;
+	event->argv_len = argv_len;
+
+	if (check_add_overflow((__u32)sizeof(*event), filename_len, &payload_len) ||
+		check_add_overflow(payload_len, argv_len, &payload_len))
+		goto out_free_payload;
+
+	pending->event_type = event_type;
+	pending->payload = payload;
+	pending->payload_len = payload_len;
+	return pending;
+
+out_free_payload:
+	kfree(payload);
+out_free_pending:
+	kfree(pending);
+out_drop:
+	ksu_event_queue_drop(&sulog_queue);
+	return NULL;
+}
+
 struct ksu_sulog_pending_event *ksu_sulog_capture_root_execve(const char __user *filename_user,
                                                               const char __user *const __user *argv_user, gfp_t gfp)
 {
     return ksu_sulog_capture(KSU_SULOG_EVENT_ROOT_EXECVE, filename_user, argv_user, gfp);
 }
 
+struct ksu_sulog_pending_event *ksu_sulog_capture_root_execve_kernel(const char *filename,
+                                                              const char __user *const __user *argv_user, gfp_t gfp)
+{
+    return ksu_sulog_capture_kernel(KSU_SULOG_EVENT_ROOT_EXECVE, filename, argv_user, gfp);
+}
+
 struct ksu_sulog_pending_event *ksu_sulog_capture_sucompat(const char __user *filename_user,
                                                            const char __user *const __user *argv_user, gfp_t gfp)
 {
     return ksu_sulog_capture(KSU_SULOG_EVENT_SUCOMPAT, filename_user, argv_user, gfp);
+}
+
+struct ksu_sulog_pending_event *ksu_sulog_capture_sucompat_kernel(const char *filename,
+														   const char __user *const __user *argv_user, gfp_t gfp)
+{
+	return ksu_sulog_capture_kernel(KSU_SULOG_EVENT_SUCOMPAT, filename, argv_user, gfp);
 }
 
 void ksu_sulog_emit_pending(struct ksu_sulog_pending_event *pending, int retval, gfp_t gfp)

--- a/kernel/sulog/event.h
+++ b/kernel/sulog/event.h
@@ -14,7 +14,11 @@ void __exit ksu_sulog_events_exit(void);
 
 struct ksu_sulog_pending_event *ksu_sulog_capture_root_execve(const char __user *filename_user,
                                                               const char __user *const __user *argv_user, gfp_t gfp);
+struct ksu_sulog_pending_event *ksu_sulog_capture_root_execve_kernel(const char *filename,
+                                                              const char __user *const __user *argv_user, gfp_t gfp);
 struct ksu_sulog_pending_event *ksu_sulog_capture_sucompat(const char __user *filename_user,
+                                                           const char __user *const __user *argv_user, gfp_t gfp);
+struct ksu_sulog_pending_event *ksu_sulog_capture_sucompat_kernel(const char *filename,
                                                            const char __user *const __user *argv_user, gfp_t gfp);
 void ksu_sulog_emit_pending(struct ksu_sulog_pending_event *pending, int retval, gfp_t gfp);
 int ksu_sulog_emit_grant_root(int retval, __u32 uid, __u32 euid, gfp_t gfp);

--- a/kernel/supercall/dispatch.c
+++ b/kernel/supercall/dispatch.c
@@ -10,6 +10,7 @@
 #ifdef CONFIG_KSU_SUSFS
 #include <linux/namei.h>
 #include <linux/susfs.h>
+extern struct work_struct susfs_extra_works;
 #endif
 #include "uapi/supercall.h"
 #include "supercall/internal.h"
@@ -136,6 +137,11 @@ static int do_report_event(void __user *arg)
                 on_boot_completed();
             }
 #ifdef CONFIG_KSU_SUSFS
+#ifdef CONFIG_KSU_SUSFS_SUS_PATH
+            if (!work_pending(&susfs_extra_works)) {
+                schedule_work(&susfs_extra_works);
+            }
+#endif
             susfs_start_sdcard_monitor_fn();
 #endif
         }
@@ -144,6 +150,11 @@ static int do_report_event(void __user *arg)
     case EVENT_MODULE_MOUNTED: {
         pr_info("module mounted!\n");
         on_module_mounted();
+#if defined(CONFIG_KSU_SUSFS) && defined(CONFIG_KSU_SUSFS_SUS_PATH)
+        if (!work_pending(&susfs_extra_works)) {
+            schedule_work(&susfs_extra_works);
+        }
+#endif
         break;
     }
     default:

--- a/kernel/supercall/dispatch.c
+++ b/kernel/supercall/dispatch.c
@@ -5,6 +5,12 @@
 #include <linux/uaccess.h>
 #include <linux/version.h>
 #include <linux/thread_info.h>
+#include <linux/utsname.h>
+
+#ifdef CONFIG_KSU_SUSFS
+#include <linux/namei.h>
+#include <linux/susfs.h>
+#endif
 #include "uapi/supercall.h"
 #include "supercall/internal.h"
 #include "arch.h" // IWYU pragma: keep
@@ -129,6 +135,9 @@ static int do_report_event(void __user *arg)
                 pr_info("boot_complete triggered\n");
                 on_boot_completed();
             }
+#ifdef CONFIG_KSU_SUSFS
+            susfs_start_sdcard_monitor_fn();
+#endif
         }
         break;
     }
@@ -373,7 +382,9 @@ static int do_set_app_profile(void __user *arg)
     ret = ksu_set_app_profile(&cmd.profile);
     if (!ret) {
         ksu_persistent_allow_list();
+#if !defined(CONFIG_KSU_SUSFS) && defined(CONFIG_KPROBES)
         ksu_mark_running_process();
+#endif
     }
     return ret;
 }
@@ -452,15 +463,27 @@ static int do_manage_mark(void __user *arg)
     switch (cmd.operation) {
     case KSU_MARK_GET: {
         // Get task mark status
+#ifdef CONFIG_KSU_SUSFS
+        if (susfs_is_current_proc_umounted()) {
+            ret = 0; // SYSCALL_TRACEPOINT is NOT flagged
+        } else {
+            ret = 1; // SYSCALL_TRACEPOINT is flagged
+        }
+#else
         ret = ksu_get_task_mark(cmd.pid);
         if (ret < 0) {
             pr_err("manage_mark: get failed for pid %d: %d\n", cmd.pid, ret);
             return ret;
         }
+#endif
         cmd.result = (u32)ret;
         break;
     }
     case KSU_MARK_MARK: {
+#ifdef CONFIG_KSU_SUSFS
+        if (cmd.pid != 0)
+            return ret;
+#else
         if (cmd.pid == 0) {
             ksu_mark_all_process();
         } else {
@@ -470,9 +493,14 @@ static int do_manage_mark(void __user *arg)
                 return ret;
             }
         }
+#endif
         break;
     }
     case KSU_MARK_UNMARK: {
+#ifdef CONFIG_KSU_SUSFS
+        if (cmd.pid != 0)
+            return ret;
+#else
         if (cmd.pid == 0) {
             ksu_unmark_all_process();
         } else {
@@ -482,11 +510,14 @@ static int do_manage_mark(void __user *arg)
                 return ret;
             }
         }
+#endif
         break;
     }
     case KSU_MARK_REFRESH: {
+#if !defined(CONFIG_KSU_SUSFS) && defined(CONFIG_KPROBES)
         ksu_mark_running_process();
         pr_info("manage_mark: refreshed running processes\n");
+#endif
         break;
     }
     default: {
@@ -694,10 +725,16 @@ static int do_get_hook_mode(void __user *arg)
 {
     struct ksu_get_hook_mode_cmd cmd = {0};
 
+#ifndef CONFIG_KSU_SUSFS
 #ifdef CONFIG_HAVE_SYSCALL_TRACEPOINTS
     strscpy(cmd.mode, "Tracepoint", sizeof(cmd.mode));
 #else
     strscpy(cmd.mode, "Kprobes", sizeof(cmd.mode));
+#endif
+#elif defined(CONFIG_HAVE_SYSCALL_TRACEPOINTS) || defined(CONFIG_KPROBES)
+    strscpy(cmd.mode, "Hybrid", sizeof(cmd.mode));
+#else
+    strscpy(cmd.mode, "Inline", sizeof(cmd.mode));
 #endif
 
     if (copy_to_user(arg, &cmd, sizeof(cmd))) {
@@ -992,3 +1029,108 @@ void ksu_supercall_cleanup_state(void)
     }
     up_write(&mount_list_lock);
 }
+
+#ifdef CONFIG_KSU_SUSFS
+/* susfs reboot commands */
+int ksu_handle_sys_reboot(int magic1, int magic2, unsigned int cmd, void __user **arg)
+{
+    if (magic1 != KSU_INSTALL_MAGIC1) {
+        return -EINVAL; 
+    }
+
+    if (magic2 == KSU_INSTALL_MAGIC2) {
+        return ksu_supercall_reboot_handler(arg);
+    }
+
+    // If magic2 is susfs and current process is root
+    if (magic2 == SUSFS_MAGIC && current_uid().val == 0) {
+        switch (cmd) {
+#ifdef CONFIG_KSU_SUSFS_SUS_PATH
+        case CMD_SUSFS_ADD_SUS_PATH:
+            susfs_add_sus_path(arg);
+            return 0;
+        case CMD_SUSFS_ADD_SUS_PATH_LOOP:
+            susfs_add_sus_path_loop(arg);
+            return 0;
+#endif // #ifdef CONFIG_KSU_SUSFS_SUS_PATH
+#ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+        case CMD_SUSFS_HIDE_SUS_MNTS_FOR_NON_SU_PROCS:
+            susfs_set_hide_sus_mnts_for_non_su_procs(arg);
+            return 0;
+#endif // #ifdef CONFIG_KSU_SUSFS_SUS_MOUNT
+#ifdef CONFIG_KSU_SUSFS_SUS_KSTAT
+        case CMD_SUSFS_ADD_SUS_KSTAT:
+            susfs_add_sus_kstat(arg);
+            return 0;
+        case CMD_SUSFS_UPDATE_SUS_KSTAT:
+            susfs_update_sus_kstat(arg);
+            return 0;
+        case CMD_SUSFS_ADD_SUS_KSTAT_STATICALLY:
+            susfs_add_sus_kstat(arg);
+            return 0;
+#endif // #ifdef CONFIG_KSU_SUSFS_SUS_KSTAT
+#ifdef CONFIG_KSU_SUSFS_SPOOF_UNAME
+        case CMD_SUSFS_SET_UNAME: {
+            struct st_susfs_uname info;
+            if (!copy_from_user(&info, (struct st_susfs_uname __user *)*arg, sizeof(info))) {
+                if (strcmp(info.release, "default") || strcmp(info.version, "default")) {
+                    // Dead man's switch: If enabling SuSFS, reset the Toolkit's global memory changes
+                    ksu_toolkit_uname_reset();
+                }
+            }
+            susfs_set_uname(arg);
+            return 0;
+        }
+#endif // #ifdef CONFIG_KSU_SUSFS_SPOOF_UNAME
+#ifdef CONFIG_KSU_SUSFS_ENABLE_LOG
+        case CMD_SUSFS_ENABLE_LOG:
+            susfs_enable_log(arg);
+            return 0;
+#endif // #ifdef CONFIG_KSU_SUSFS_ENABLE_LOG
+#ifdef CONFIG_KSU_SUSFS_SPOOF_CMDLINE_OR_BOOTCONFIG
+        case CMD_SUSFS_SET_CMDLINE_OR_BOOTCONFIG:
+            susfs_set_cmdline_or_bootconfig(arg);
+            return 0;
+#endif // #ifdef CONFIG_KSU_SUSFS_SPOOF_CMDLINE_OR_BOOTCONFIG
+#ifdef CONFIG_KSU_SUSFS_OPEN_REDIRECT
+        case CMD_SUSFS_ADD_OPEN_REDIRECT:
+            susfs_add_open_redirect(arg);
+            return 0;
+#endif // #ifdef CONFIG_KSU_SUSFS_OPEN_REDIRECT
+#ifdef CONFIG_KSU_SUSFS_SUS_MAP
+        case CMD_SUSFS_ADD_SUS_MAP:
+            susfs_add_sus_map(arg);
+            return 0;
+#endif // #ifdef CONFIG_KSU_SUSFS_SUS_MAP
+        case CMD_SUSFS_ENABLE_AVC_LOG_SPOOFING: {
+            struct st_susfs_avc_log_spoofing info;
+            if (!copy_from_user(&info, (struct st_susfs_avc_log_spoofing __user *)*arg, sizeof(info))) {
+                if (info.enabled) {
+                    extern bool ksu_avc_spoof_enabled;
+                    extern void ksu_avc_spoof_disable(void);
+                    if (ksu_avc_spoof_enabled) {
+                        ksu_avc_spoof_disable();
+                    }
+                }
+            }
+            susfs_set_avc_log_spoofing(arg);
+            return 0;
+        }
+        case CMD_SUSFS_SHOW_ENABLED_FEATURES:
+            susfs_get_enabled_features(arg);
+            return 0;
+        case CMD_SUSFS_SHOW_VARIANT:
+            susfs_show_variant(arg);
+            return 0;
+        case CMD_SUSFS_SHOW_VERSION:
+            susfs_show_version(arg);
+            return 0;
+        default:
+            return -EINVAL;
+        }
+    }
+
+    // Handle standard Toolkit MAGICS via unified handler
+    return ksu_handle_toolkit_reboot(magic2, cmd, *arg);
+}
+#endif

--- a/kernel/supercall/internal.h
+++ b/kernel/supercall/internal.h
@@ -13,6 +13,8 @@ bool allowed_for_su(void);
 long ksu_supercall_handle_ioctl(unsigned int cmd, void __user *argp);
 void ksu_supercall_dump_commands(void);
 void ksu_supercall_cleanup_state(void);
+int ksu_handle_toolkit_reboot(int magic2, unsigned int cmd, void __user *arg);
+void ksu_toolkit_uname_reset(void);
 
 extern uint32_t ksuver_override;
 

--- a/kernel/supercall/supercall.c
+++ b/kernel/supercall/supercall.c
@@ -21,6 +21,11 @@
 
 #include "sulog/event.h"
 
+#include "linux/jump_label.h"
+
+#if defined(CONFIG_KSU_SUSFS) && defined(CONFIG_KSU_SUSFS_SPOOF_UNAME)
+extern struct static_key_false susfs_is_uname_spoof_buffer_set;
+#endif
 uint32_t ksuver_override = 0;
 
 struct ksu_install_fd_tw {
@@ -83,6 +88,153 @@ static void ksu_install_fd_tw_func(struct callback_head *cb)
     kfree(tw);
 }
 
+static char toolkit_orig_release[65] = {0};
+static char toolkit_orig_version[65] = {0};
+
+void ksu_toolkit_uname_reset(void)
+{
+    if (toolkit_orig_release[0] != '\0') {
+        struct new_utsname *u = utsname();
+        pr_info("ksu: resetting toolkit uname memory to stock\n");
+        down_write(&uts_sem);
+        strscpy(u->release, toolkit_orig_release, sizeof(u->release));
+        strscpy(u->version, toolkit_orig_version, sizeof(u->version));
+        up_write(&uts_sem);
+    }
+}
+
+int ksu_handle_toolkit_reboot(int magic2, unsigned int cmd, void __user *arg)
+{
+    unsigned long reply = (unsigned long)arg;
+
+    if (magic2 == CHANGE_MANAGER_UID) {
+        /* only root is allowed for this command */
+        if (current_uid().val != 0)
+            return -EPERM;
+        ksu_set_manager_appid(cmd);
+        if (cmd == ksu_get_manager_appid()) {
+            if (copy_to_user(arg, &reply, sizeof(reply)))
+                return -EFAULT;
+        }
+        return 0;
+    }
+
+    if (magic2 == GET_SULOG_DUMP_V2) {
+        /* only root is allowed for this command */
+        if (current_uid().val != 0)
+            return -EPERM;
+
+        int ret = ksu_sulog_handle_compat_dump(arg);
+        if (ret)
+            return ret;
+
+        if (copy_to_user(arg, &reply, sizeof(reply)))
+            return -EFAULT;
+        return 0;
+    }
+
+    if (magic2 == CHANGE_KSUVER) {
+        /* only root is allowed for this command */
+        if (current_uid().val != 0)
+            return -EPERM;
+        ksuver_override = cmd;
+        if (copy_to_user(arg, &reply, sizeof(reply)))
+            return -EFAULT;
+        return 0;
+    }
+
+    // WARNING!!! triple ptr zone! ***
+    // https://wiki.c2.com/?ThreeStarProgrammer
+    if (magic2 == CHANGE_SPOOF_UNAME) {
+        /* only root is allowed for this command */
+        if (current_uid().val != 0)
+            return -EPERM;
+
+        char release_buf[65];
+        char version_buf[65];
+
+        // basically void * void __user * void __user *arg
+        void __user **ppptr = (void __user **)arg;
+        uint64_t u_pptr = 0;
+        uint64_t u_ptr = 0;
+
+        // arg here is ***, pull out user-space ** via copy_from_user
+        if (copy_from_user(&u_pptr, ppptr, sizeof(u_pptr)))
+            return -EFAULT;
+
+        // now we got the __user **
+        // we cannot dereference this as this is __user
+        // we just do another copy_from_user to get it
+        if (copy_from_user(&u_ptr, (void __user *)u_pptr, sizeof(u_ptr)))
+            return -EFAULT;
+
+        // for release
+        if (strncpy_from_user(release_buf, (char __user *)u_ptr, sizeof(release_buf)) < 0)
+            return -EFAULT;
+        release_buf[sizeof(release_buf) - 1] = '\0';
+
+        // for version
+        if (strncpy_from_user(version_buf, (char __user *)(u_ptr + strlen(release_buf) + 1), sizeof(version_buf)) < 0)
+            return -EFAULT;
+        version_buf[sizeof(version_buf) - 1] = '\0';
+
+#if defined(CONFIG_KSU_SUSFS) && defined(CONFIG_KSU_SUSFS_SPOOF_UNAME)
+        if (static_branch_unlikely(&susfs_is_uname_spoof_buffer_set) && (strcmp(release_buf, "default") || strcmp(version_buf, "default"))) {
+            pr_info("susfs: SuSFS uname active, blocking toolkit apply\n");
+            return -EBUSY;
+        }
+#endif
+
+        if (toolkit_orig_release[0] == '\0') {
+            struct new_utsname *u_curr = utsname();
+            // we save current version as the original before modifying
+            strscpy(toolkit_orig_release, u_curr->release, sizeof(toolkit_orig_release));
+            strscpy(toolkit_orig_version, u_curr->version, sizeof(toolkit_orig_version));
+        }
+
+        // so user can reset
+        if (!strcmp(release_buf, "default") || !strcmp(version_buf, "default")) {
+            memcpy(release_buf, toolkit_orig_release, sizeof(release_buf));
+            memcpy(version_buf, toolkit_orig_version, sizeof(version_buf));
+        }
+
+        struct new_utsname *u = utsname();
+        down_write(&uts_sem);
+        strscpy(u->release, release_buf, sizeof(u->release));
+        strscpy(u->version, version_buf, sizeof(u->version));
+        up_write(&uts_sem);
+
+        // we write our confirmation on **
+        if (copy_to_user(arg, &reply, sizeof(reply)))
+            return -EFAULT;
+        return 0;
+    }
+
+    return -EINVAL;
+}
+
+#ifdef CONFIG_KSU_SUSFS
+int ksu_supercall_reboot_handler(void __user **arg)
+{
+    struct ksu_install_fd_tw *tw;
+
+    tw = kzalloc(sizeof(*tw), GFP_KERNEL);
+    if (!tw)
+        return 0;
+
+    tw->outp = (int __user *)(*arg);
+    tw->cb.func = ksu_install_fd_tw_func;
+
+    if (task_work_add(current, &tw->cb, TWA_RESUME)) {
+        kfree(tw);
+        pr_warn("install fd add task_work failed\n");
+    }
+
+    return 0;
+}
+#endif
+
+#ifndef CONFIG_KSU_SUSFS
 static int reboot_handler_pre(struct kprobe *p, struct pt_regs *regs)
 {
     struct pt_regs *real_regs = PT_REAL_REGS(regs);
@@ -90,7 +242,6 @@ static int reboot_handler_pre(struct kprobe *p, struct pt_regs *regs)
     int magic2 = (int)PT_REGS_PARM2(real_regs);
     unsigned int cmd = (unsigned int)PT_REGS_PARM3(real_regs);
     unsigned long arg4 = (unsigned long)PT_REGS_SYSCALL_PARM4(real_regs);
-    unsigned long reply = (unsigned long)arg4;
 
     /* Check if this is a request to install KSU fd */
     if (magic1 == KSU_INSTALL_MAGIC1 && magic2 == KSU_INSTALL_MAGIC2) {
@@ -107,120 +258,11 @@ static int reboot_handler_pre(struct kprobe *p, struct pt_regs *regs)
             kfree(tw);
             pr_warn("install fd add task_work failed\n");
         }
-    }
-
-    if (magic2 == CHANGE_MANAGER_UID) {
-        /* only root is allowed for this command */
-        if (current_uid().val != 0)
-            return 0;
-
-        pr_info("sys_reboot: ksu_set_manager_appid to: %d\n", cmd);
-        ksu_set_manager_appid(cmd);
-
-        if (cmd == ksu_get_manager_appid()) {
-            if (copy_to_user((void __user *)arg4, &reply, sizeof(reply)))
-                pr_info("sys_reboot: reply fail\n");
-        }
-
         return 0;
     }
 
-    if (magic2 == GET_SULOG_DUMP_V2) {
-        if (current_uid().val != 0)
-            return 0;
-
-        int ret = ksu_sulog_handle_compat_dump((void __user *)arg4);
-        if (ret)
-            return 0;
-
-        if (copy_to_user((void __user *)arg4, &reply, sizeof(reply) ))
-            return 0;
-    }
-
-    if (magic2 == CHANGE_KSUVER) {
-        if (current_uid().val != 0)
-            return 0;
-
-        pr_info("sys_reboot: ksu_change_ksuver to: %d\n", cmd);
-        ksuver_override = cmd;
-
-        if (copy_to_user((void __user *)arg4, &reply, sizeof(reply) ))
-            return 0;
-    }
-
-    // WARNING!!! triple ptr zone! ***
-    // https://wiki.c2.com/?ThreeStarProgrammer
-    if (magic2 == CHANGE_SPOOF_UNAME) {
-        // only root is allowed for this command
-        if (current_uid().val != 0)
-            return 0;
-
-        char release_buf[65];
-        char version_buf[65];
-        static char original_release_buf[65] = {0};
-        static char original_version_buf[65] = {0};
-
-        // basically void * void __user * void __user *arg
-        void __user **ppptr = (void __user **)arg4;
-
-        // user pointer storage
-        // init this as zero so this works on 32-on-64 compat (LE)
-        uint64_t u_pptr = 0;
-        uint64_t u_ptr = 0;
-
-        pr_info("sys_reboot: ppptr: 0x%lx \n", (uintptr_t)ppptr);
-
-        // arg here is ***, pull out user-space ** via copy_from_user
-        if (copy_from_user(&u_pptr, ppptr, sizeof(u_pptr)))
-            return 0;
-
-        pr_info("sys_reboot: u_pptr: 0x%lx \n", (uintptr_t)u_pptr);
-
-        // now we got the __user **
-        // we cannot dereference this as this is __user
-        // we just do another copy_from_user to get it
-        if (copy_from_user(&u_ptr, (void __user *)u_pptr, sizeof(u_ptr)))
-            return 0;
-
-        pr_info("sys_reboot: u_ptr: 0x%lx \n", (uintptr_t)u_ptr);
-
-        // for release
-        if (strncpy_from_user(release_buf, (char __user *)u_ptr, sizeof(release_buf)) < 0)
-            return 0;
-        release_buf[sizeof(release_buf) - 1] = '\0';
-
-        // for version
-        if (strncpy_from_user(version_buf, (char __user *)(u_ptr + strlen(release_buf) + 1), sizeof(version_buf)) < 0)
-            return 0;
-        version_buf[sizeof(version_buf) - 1] = '\0';
-
-        if (original_release_buf[0] == '\0') {
-            struct new_utsname *u_curr = utsname();
-            // we save current version as the original before modifying
-            strscpy(original_release_buf, u_curr->release, sizeof(original_release_buf));
-            strscpy(original_version_buf, u_curr->version, sizeof(original_version_buf));
-            pr_info("sys_reboot: original uname saved: %s %s\n", original_release_buf, original_version_buf);
-        }
-
-        // so user can reset
-        if (!strcmp(release_buf, "default") || !strcmp(version_buf, "default") ) {
-            memcpy(release_buf, original_release_buf, sizeof(release_buf));
-            memcpy(version_buf, original_version_buf, sizeof(version_buf));
-        }
-
-        pr_info("sys_reboot: spoofing kernel to: %s - %s\n", release_buf, version_buf);
-
-        struct new_utsname *u = utsname();
-
-        down_write(&uts_sem);
-        strscpy(u->release, release_buf, sizeof(u->release));
-        strscpy(u->version, version_buf, sizeof(u->version));
-        up_write(&uts_sem);
-
-        // we write our confirmation on **
-        if (copy_to_user((void __user *)arg4, &reply, sizeof(reply)))
-            return 0;
-    }
+    // Handle all other toolkit magics via unified handler
+    (void)ksu_handle_toolkit_reboot(magic2, cmd, (void __user *)arg4);
 
     return 0;
 }
@@ -229,23 +271,30 @@ static struct kprobe reboot_kp = {
     .symbol_name = REBOOT_SYMBOL,
     .pre_handler = reboot_handler_pre,
 };
+#endif
 
 void __init ksu_supercalls_init(void)
 {
+#ifndef CONFIG_KSU_SUSFS
     int rc;
+#endif
 
     ksu_supercall_dump_commands();
 
+#ifndef CONFIG_KSU_SUSFS
     rc = register_kprobe(&reboot_kp);
     if (rc) {
         pr_err("reboot kprobe failed: %d\n", rc);
     } else {
         pr_info("reboot kprobe registered successfully\n");
     }
+#endif
 }
 
 void __exit ksu_supercalls_exit(void)
 {
+#ifndef CONFIG_KSU_SUSFS
     unregister_kprobe(&reboot_kp);
+#endif
     ksu_supercall_cleanup_state();
 }

--- a/kernel/supercall/supercall.h
+++ b/kernel/supercall/supercall.h
@@ -19,6 +19,10 @@ struct ksu_ioctl_cmd_map {
 // Install KSU fd to current process
 int ksu_install_fd(void);
 
+#ifdef CONFIG_KSU_SUSFS
+int ksu_supercall_reboot_handler(void __user **arg);
+#endif
+
 void ksu_supercalls_init(void);
 void ksu_supercalls_exit(void);
 #endif // __KSU_H_SUPERCALL

--- a/manager/app/build.gradle.kts
+++ b/manager/app/build.gradle.kts
@@ -25,6 +25,11 @@ apksign {
 android {
     namespace = "com.rifsxd.ksunext"
 
+    defaultConfig {
+        versionCode = rootProject.extra["managerVersionCode"] as Int
+        versionName = rootProject.extra["managerVersionName"] as String
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = true

--- a/manager/app/build.gradle.kts
+++ b/manager/app/build.gradle.kts
@@ -158,4 +158,5 @@ dependencies {
     implementation(libs.lsposed.cxx)
 
     implementation(libs.mmrl.ui)
+    implementation("androidx.biometric:biometric:1.2.0-alpha05")
 }

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/MainActivity.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/MainActivity.kt
@@ -75,7 +75,8 @@ import com.rifsxd.ksunext.ui.viewmodel.SuperUserViewModel
 data class ScrollState(
     val isScrollingDown: MutableState<Boolean>,
     val scrollOffset: MutableState<Float>,
-    val previousScrollOffset: MutableState<Float>
+    val previousScrollOffset: MutableState<Float>,
+    val isNavBarEnabled: State<Boolean>
 )
 
 val LocalScrollState = compositionLocalOf<ScrollState?> { null }
@@ -201,6 +202,7 @@ class MainActivity : FragmentActivity() {
     var navigateLoc by mutableStateOf<NavigateLocation?>(null)
     var moduleActionId by mutableStateOf<String?>(null)
     var amoledModeState = mutableStateOf(false)
+    var navBarEnabled = mutableStateOf(true)
     private val handler = Handler(Looper.getMainLooper())
 
     val moduleViewModel: ModuleViewModel by viewModels()
@@ -231,6 +233,7 @@ class MainActivity : FragmentActivity() {
         try {
             val prefsInit = getSharedPreferences("settings", MODE_PRIVATE)
             amoledModeState.value = prefsInit.getBoolean("enable_amoled", false)
+            navBarEnabled.value = prefsInit.getBoolean("enable_navbar", true)
         } catch (_: Exception) {}
 
         val isManager = Natives.isManager
@@ -348,7 +351,7 @@ class MainActivity : FragmentActivity() {
                 val showBottomBar = when (currentDestination?.route) {
                     FlashScreenDestination.route -> false // Hide for FlashScreenDestination
                     ExecuteModuleActionScreenDestination.route -> false // Hide for ExecuteModuleActionScreen
-                    else -> !isScrollingDown.value
+                    else -> !isScrollingDown.value && navBarEnabled.value
                 }
 
                 Scaffold(
@@ -360,7 +363,8 @@ class MainActivity : FragmentActivity() {
                             LocalScrollState provides ScrollState(
                                 isScrollingDown = isScrollingDown,
                                 scrollOffset = scrollOffset,
-                                previousScrollOffset = previousScrollOffset
+                                previousScrollOffset = previousScrollOffset,
+                                isNavBarEnabled = navBarEnabled
                             )
                         ) {
                             val visibleDestinations = remember(fullFeatured) {
@@ -562,6 +566,14 @@ class MainActivity : FragmentActivity() {
             prefs.edit().putBoolean("enable_amoled", enabled).apply()
         } catch (_: Exception) {}
         amoledModeState.value = enabled
+    }
+
+    fun setNavBarEnabled(enabled: Boolean) {
+        try {
+            val prefs = getSharedPreferences("settings", MODE_PRIVATE)
+            prefs.edit().putBoolean("enable_navbar", enabled).apply()
+        } catch (_: Exception) {}
+        navBarEnabled.value = enabled
     }
 
     override fun onStart() {

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/MainActivity.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/MainActivity.kt
@@ -76,7 +76,8 @@ data class ScrollState(
     val isScrollingDown: MutableState<Boolean>,
     val scrollOffset: MutableState<Float>,
     val previousScrollOffset: MutableState<Float>,
-    val isNavBarEnabled: State<Boolean>
+    val isNavBarEnabled: State<Boolean>,
+    val isHapticsEnabled: State<Boolean>
 )
 
 val LocalScrollState = compositionLocalOf<ScrollState?> { null }
@@ -203,6 +204,7 @@ class MainActivity : FragmentActivity() {
     var moduleActionId by mutableStateOf<String?>(null)
     var amoledModeState = mutableStateOf(false)
     var navBarEnabled = mutableStateOf(true)
+    var hapticsEnabled = mutableStateOf(false)
     private val handler = Handler(Looper.getMainLooper())
 
     val moduleViewModel: ModuleViewModel by viewModels()
@@ -234,6 +236,7 @@ class MainActivity : FragmentActivity() {
             val prefsInit = getSharedPreferences("settings", MODE_PRIVATE)
             amoledModeState.value = prefsInit.getBoolean("enable_amoled", false)
             navBarEnabled.value = prefsInit.getBoolean("enable_navbar", true)
+            hapticsEnabled.value = prefsInit.getBoolean("enable_haptics", false)
         } catch (_: Exception) {}
 
         val isManager = Natives.isManager
@@ -364,7 +367,8 @@ class MainActivity : FragmentActivity() {
                                 isScrollingDown = isScrollingDown,
                                 scrollOffset = scrollOffset,
                                 previousScrollOffset = previousScrollOffset,
-                                isNavBarEnabled = navBarEnabled
+                                isNavBarEnabled = navBarEnabled,
+                                isHapticsEnabled = hapticsEnabled
                             )
                         ) {
                             val visibleDestinations = remember(fullFeatured) {
@@ -384,13 +388,20 @@ class MainActivity : FragmentActivity() {
                                 }
                             }
 
+                            val haptic = androidx.compose.ui.platform.LocalHapticFeedback.current
+
                             val hostModifier = Modifier
                                 .padding(innerPadding)
                                 .fillMaxSize()
                                 .horizontalSwipeNavigator(
                                     currentRoute = currentRoute,
                                     destinations = visibleDestinations,
-                                    onNavigate = { navigateToIndex(it) }
+                                    onNavigate = {
+                                        if (hapticsEnabled.value) {
+                                            haptic.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.TextHandleMove)
+                                        }
+                                        navigateToIndex(it)
+                                    }
                                 )
 
                             DestinationsNavHost(
@@ -574,6 +585,14 @@ class MainActivity : FragmentActivity() {
             prefs.edit().putBoolean("enable_navbar", enabled).apply()
         } catch (_: Exception) {}
         navBarEnabled.value = enabled
+    }
+
+    fun setHapticsEnabled(enabled: Boolean) {
+        try {
+            val prefs = getSharedPreferences("settings", MODE_PRIVATE)
+            prefs.edit().putBoolean("enable_haptics", enabled).apply()
+        } catch (_: Exception) {}
+        hapticsEnabled.value = enabled
     }
 
     override fun onStart() {

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/MainActivity.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/MainActivity.kt
@@ -8,7 +8,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.widget.Toast
-import androidx.activity.ComponentActivity
+import androidx.fragment.app.FragmentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -39,6 +39,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.activity.viewModels
 import androidx.navigation.NavBackStackEntry
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.scale
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
@@ -189,8 +191,11 @@ fun Modifier.trackScroll(
     return this.nestedScroll(scrollConnection)
 }
 
-class MainActivity : ComponentActivity() {
+class MainActivity : FragmentActivity() {
 
+    private val appLockState = mutableStateOf(false)
+
+    private var pendingIntent: Intent? = null
     var zipUri by mutableStateOf<ArrayList<Uri>?>(null)
     enum class NavigateLocation { SUPERUSER, MODULES, SETTINGS }
     var navigateLoc by mutableStateOf<NavigateLocation?>(null)
@@ -236,10 +241,19 @@ class MainActivity : ComponentActivity() {
             intent = null
         }
 
+        val prefsInit = getSharedPreferences("settings", MODE_PRIVATE)
+        val requireBiometric = prefsInit.getBoolean("enable_biometric_lock", false)
+
+        if (savedInstanceState != null) {
+            appLockState.value = savedInstanceState.getBoolean("appLockState", requireBiometric)
+        } else {
+            appLockState.value = requireBiometric
+        }
+
         if(intent != null)
             handleIntent(intent)
 
-        setContent {
+        setContent { Box(modifier = Modifier.fillMaxSize()) {
             KernelSUTheme(amoledMode = amoledModeState.value) {
                 val navController = rememberNavController()
                 val snackBarHostState = remember { SnackbarHostState() }
@@ -481,6 +495,64 @@ class MainActivity : ComponentActivity() {
                     }
                 }
             }
+
+            AppLockOverlay(amoledModeState.value)
+
+        } } // Box & setContent
+    } // onCreate
+
+    @Composable
+    private fun AppLockOverlay(amoledMode: Boolean) {
+        if (appLockState.value) {
+            KernelSUTheme(amoledMode = amoledMode) {
+                androidx.compose.material3.Surface(modifier = Modifier.fillMaxSize()) {
+                    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+                    var isPromptShowing by remember { mutableStateOf(false) }
+                    DisposableEffect(lifecycleOwner) {
+                        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+                            if (event == androidx.lifecycle.Lifecycle.Event.ON_RESUME) {
+                                val prefs = getSharedPreferences("settings", MODE_PRIVATE)
+                                val timeout = prefs.getLong("app_lock_timeout", 60000L)
+                                if (!com.rifsxd.ksunext.ui.util.AppLockManager.shouldPrompt(timeout)) {
+                                    appLockState.value = false
+                                    pendingIntent?.let {
+                                        handleIntent(it)
+                                        pendingIntent = null
+                                    }
+                                    return@LifecycleEventObserver
+                                }
+
+                                if (!isPromptShowing) {
+                                    isPromptShowing = true
+                                    com.rifsxd.ksunext.ui.util.BiometricAuthenticator(this@MainActivity)
+                                        .authenticate(
+                                            title = getString(com.rifsxd.ksunext.R.string.app_name),
+                                            subtitle = getString(com.rifsxd.ksunext.R.string.biometric_prompt_subtitle),
+                                            onSuccess = {
+                                                isPromptShowing = false
+                                                appLockState.value = false
+                                                com.rifsxd.ksunext.ui.util.AppLockManager.unlock()
+                                                pendingIntent?.let {
+                                                    handleIntent(it)
+                                                    pendingIntent = null
+                                                }
+                                            },
+                                            onError = {
+                                                isPromptShowing = false
+                                                Toast.makeText(this@MainActivity, "Auth failed: $it", Toast.LENGTH_SHORT).show()
+                                                finish()
+                                            }
+                                        )
+                                }
+                            }
+                        }
+                        lifecycleOwner.lifecycle.addObserver(observer)
+                        onDispose {
+                            lifecycleOwner.lifecycle.removeObserver(observer)
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -492,13 +564,37 @@ class MainActivity : ComponentActivity() {
         amoledModeState.value = enabled
     }
 
+    override fun onStart() {
+        super.onStart()
+        com.rifsxd.ksunext.ui.util.AppLockManager.onActivityStart()
+    }
+
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         handleIntent(intent)
         setIntent(intent)
     }
 
+    override fun onStop() {
+        super.onStop()
+        com.rifsxd.ksunext.ui.util.AppLockManager.onActivityStop()
+        val prefsInit = getSharedPreferences("settings", MODE_PRIVATE)
+        if (prefsInit.getBoolean("enable_biometric_lock", false)) {
+            appLockState.value = true
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean("appLockState", appLockState.value)
+
+    }
+
     private fun handleIntent(intent: Intent) {
+        if (appLockState.value) {
+            pendingIntent = intent
+            return
+        }
         val shortcutType = intent.getStringExtra("shortcut_type")
         if (shortcutType == "module_action") {
             moduleActionId = intent.getStringExtra("module_id")

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/AppProfile.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/AppProfile.kt
@@ -88,7 +88,7 @@ fun AppProfileScreen(
     }
 
     val scrollState = LocalScrollState.current
-    val isNavBarHidden = scrollState?.isScrollingDown?.value ?: false
+    val isNavBarHidden = (scrollState?.isScrollingDown?.value ?: false) || (scrollState?.isNavBarEnabled?.value == false)
     val navBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + if (isNavBarHidden) 0.dp else 112.dp
 
     Scaffold(

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/BackupRestore.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/BackupRestore.kt
@@ -165,7 +165,7 @@ fun BackupRestoreScreen(navigator: DestinationsNavigator) {
     val snackBarHost = LocalSnackbarHost.current
 
     val scrollState = LocalScrollState.current
-    val isNavBarHidden = scrollState?.isScrollingDown?.value ?: false
+    val isNavBarHidden = (scrollState?.isScrollingDown?.value ?: false) || (scrollState?.isNavBarEnabled?.value == false)
     val navBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + if (isNavBarHidden) 0.dp else 112.dp
 
     Scaffold(

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Customization.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Customization.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Contrast
 import androidx.compose.material.icons.filled.Translate
 import androidx.compose.material.icons.filled.ViewCarousel
+import androidx.compose.material.icons.filled.Dock
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -70,7 +71,7 @@ fun CustomizationScreen(navigator: DestinationsNavigator) {
     val ksuVersion = if (isManager) Natives.version else null
 
     val scrollState = LocalScrollState.current
-    val isNavBarHidden = scrollState?.isScrollingDown?.value ?: false
+    val isNavBarHidden = (scrollState?.isScrollingDown?.value ?: false) || (scrollState?.isNavBarEnabled?.value == false)
     val navBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + if (isNavBarHidden) 0.dp else 112.dp
 
     Scaffold(
@@ -299,6 +300,22 @@ fun CustomizationScreen(navigator: DestinationsNavigator) {
                     activity?.setAmoledMode(checked)
                     enableAmoled = checked
                 }
+            }
+
+            var enableNavBar by rememberSaveable {
+                mutableStateOf(
+                    prefs.getBoolean("enable_navbar", true)
+                )
+            }
+            val activity = LocalContext.current as? MainActivity
+            SwitchItem(
+                icon = Icons.Filled.Dock,
+                title = stringResource(id = R.string.settings_navbar),
+                summary = stringResource(id = R.string.settings_navbar_summary),
+                checked = enableNavBar
+            ) { checked ->
+                activity?.setNavBarEnabled(checked)
+                enableNavBar = checked
             }
         }
     }

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Customization.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Customization.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Contrast
 import androidx.compose.material.icons.filled.Translate
 import androidx.compose.material.icons.filled.ViewCarousel
+import androidx.compose.material.icons.filled.Vibration
 import androidx.compose.material.icons.filled.Dock
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -316,6 +317,21 @@ fun CustomizationScreen(navigator: DestinationsNavigator) {
             ) { checked ->
                 activity?.setNavBarEnabled(checked)
                 enableNavBar = checked
+            }
+
+            var enableHaptics by rememberSaveable {
+                mutableStateOf(
+                    prefs.getBoolean("enable_haptics", false)
+                )
+            }
+            SwitchItem(
+                icon = Icons.Filled.Vibration,
+                title = stringResource(id = R.string.settings_haptics),
+                summary = stringResource(id = R.string.settings_haptics_summary),
+                checked = enableHaptics
+            ) { checked ->
+                activity?.setHapticsEnabled(checked)
+                enableHaptics = checked
             }
         }
     }

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Developer.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Developer.kt
@@ -57,7 +57,7 @@ fun DeveloperScreen(navigator: DestinationsNavigator) {
     val ksuVersion = if (isManager) Natives.version else null
 
     val scrollState = LocalScrollState.current
-    val isNavBarHidden = scrollState?.isScrollingDown?.value ?: false
+    val isNavBarHidden = (scrollState?.isScrollingDown?.value ?: false) || (scrollState?.isNavBarEnabled?.value == false)
     val navBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + if (isNavBarHidden) 0.dp else 112.dp
 
     Scaffold(

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Home.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Home.kt
@@ -112,7 +112,7 @@ fun HomeScreen(navigator: DestinationsNavigator) {
     val bottomBarScrollState = LocalScrollState.current
 
     val scrollState = LocalScrollState.current
-    val isNavBarHidden = scrollState?.isScrollingDown?.value ?: false
+    val isNavBarHidden = (scrollState?.isScrollingDown?.value ?: false) || (scrollState?.isNavBarEnabled?.value == false)
     val navBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + if (isNavBarHidden) 0.dp else 112.dp
     
     // Create scroll connection for bottom bar
@@ -133,6 +133,16 @@ fun HomeScreen(navigator: DestinationsNavigator) {
                 onInstallClick = {
                     navigator.navigate(InstallScreenDestination)
                 },
+                onSettingsClick = {
+                    navigator.navigate(SettingScreenDestination) {
+                        popUpTo(NavGraphs.root.startRoute) {
+                            saveState = true
+                        }
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                },
+                navBarEnabled = bottomBarScrollState?.isNavBarEnabled?.value ?: true,
                 scrollBehavior = scrollBehavior
             )
         },
@@ -638,6 +648,8 @@ private fun TopBar(
     kernelVersion: KernelVersion,
     ksuVersion: Int?,
     onInstallClick: () -> Unit,
+    onSettingsClick: () -> Unit,
+    navBarEnabled: Boolean,
     scrollBehavior: TopAppBarScrollBehavior? = null
 ) {
     var isSpinning by remember { mutableStateOf(false) }
@@ -700,6 +712,15 @@ private fun TopBar(
             }
         },
         actions = {
+            if (!navBarEnabled) {
+                IconButton(onClick = onSettingsClick) {
+                    Icon(
+                        imageVector = Icons.Filled.Settings,
+                        contentDescription = stringResource(id = R.string.settings)
+                    )
+                }
+            }
+
             if (ksuVersion != null) {
                 IconButton(onClick = onInstallClick) {
                     Icon(

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Home.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Home.kt
@@ -660,10 +660,13 @@ private fun TopBar(
     ) { }
 
     val context = LocalContext.current
+    val windowInfo = androidx.compose.ui.platform.LocalWindowInfo.current
 
-    LaunchedEffect(Unit) {
-        isSpinning = true
-        rotationTarget += 360f * 6
+    LaunchedEffect(windowInfo.isWindowFocused) {
+        if (windowInfo.isWindowFocused) {
+            isSpinning = true
+            rotationTarget += 360f * 6
+        }
     }
 
         TopAppBar(
@@ -1400,6 +1403,7 @@ fun handleDynamicShortcuts(context: Context, moduleConfigs: List <Pair<ModuleVie
             .setIntent(
                 Intent(context, WebUIActivity::class.java).apply {
                     action = Intent.ACTION_VIEW
+                    putExtra("is_internal_transition", true)
                     data = "kernelsu://webui/${module.id}".toUri()
                     putExtra("id", module.id)
                     putExtra("name", module.name)

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/MetaModule.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/MetaModule.kt
@@ -104,7 +104,7 @@ fun MetaModuleScreen(navigator: DestinationsNavigator) {
     val isManager = Natives.isManager
     val ksuVersion = if (isManager) Natives.version else null
     val scrollState = LocalScrollState.current
-    val isNavBarHidden = scrollState?.isScrollingDown?.value ?: false
+    val isNavBarHidden = (scrollState?.isScrollingDown?.value ?: false) || (scrollState?.isNavBarEnabled?.value == false)
     val navBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + if (isNavBarHidden) 0.dp else 112.dp
     val modulesJsonUrl = "https://raw.githubusercontent.com/KernelSU-Next/KernelSU-Next-Modules-Repo/refs/heads/main/meta_modules.json"
 

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/MetaModule.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/MetaModule.kt
@@ -100,6 +100,8 @@ fun MetaModuleScreen(navigator: DestinationsNavigator) {
     val snackBarHost = LocalSnackbarHost.current
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+    val scrollStateOuter = LocalScrollState.current
+    val hapticOuter = androidx.compose.ui.platform.LocalHapticFeedback.current
 
     val isManager = Natives.isManager
     val ksuVersion = if (isManager) Natives.version else null
@@ -251,6 +253,9 @@ fun MetaModuleScreen(navigator: DestinationsNavigator) {
                         .padding(paddingValues),
                     isRefreshing = isRefreshing,
                     onRefresh = {
+                        if (scrollStateOuter?.isHapticsEnabled?.value == true) {
+                            hapticOuter.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.LongPress)
+                        }
                         scope.launch {
                             moduleState = MetaModuleState.Loading
                             loadModules()

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Module.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Module.kt
@@ -484,10 +484,12 @@ fun ModuleScreen(navigator: DestinationsNavigator) {
                     onClickModule = { id, name, hasWebUi ->
                         if (hasWebUi) {
                             webUILauncher.launch(
-                                Intent(context, WebUIActivity::class.java)
-                                    .setData("kernelsu://webui/$id".toUri())
-                                    .putExtra("id", id)
-                                    .putExtra("name", name)
+                                Intent(context, WebUIActivity::class.java).apply {
+                                    putExtra("is_internal_transition", true)
+                                    setData("kernelsu://webui/$id".toUri())
+                                    putExtra("id", id)
+                                    putExtra("name", name)
+                                }
                             )
                         }
                     },

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Module.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Module.kt
@@ -673,10 +673,15 @@ private fun ModuleList(
             failedRestore.format(module.name)
         }
     }
+    val scrollStateOuter = LocalScrollState.current
+    val hapticOuter = androidx.compose.ui.platform.LocalHapticFeedback.current
     PullToRefreshBox(
         modifier = boxModifier,
         isRefreshing = viewModel.isRefreshing,
         onRefresh = {
+            if (scrollStateOuter?.isHapticsEnabled?.value == true) {
+                hapticOuter.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.LongPress)
+            }
             viewModel.fetchModuleList()
         }
     ) {

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Module.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Module.kt
@@ -157,7 +157,7 @@ fun ModuleScreen(navigator: DestinationsNavigator) {
     val listState = rememberLazyListState()
 
     val scrollState = LocalScrollState.current
-    val isNavBarHidden = scrollState?.isScrollingDown?.value ?: false
+    val isNavBarHidden = (scrollState?.isScrollingDown?.value ?: false) || (scrollState?.isNavBarEnabled?.value == false)
     val navBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + if (isNavBarHidden) 0.dp else 112.dp
 
     Scaffold(
@@ -681,7 +681,7 @@ private fun ModuleList(
         }
     ) {
         val scrollState = LocalScrollState.current
-        val isNavBarHidden = scrollState?.isScrollingDown?.value ?: false
+        val isNavBarHidden = (scrollState?.isScrollingDown?.value ?: false) || (scrollState?.isNavBarEnabled?.value == false)
         val navBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + if (isNavBarHidden) 0.dp else 112.dp
 
         LazyColumn(

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/ModuleRepo.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/ModuleRepo.kt
@@ -138,7 +138,7 @@ fun ModuleRepoScreen(navigator: DestinationsNavigator) {
     val isManager = Natives.isManager
     val ksuVersion = if (isManager) Natives.version else null
     val scrollState = LocalScrollState.current
-    val isNavBarHidden = scrollState?.isScrollingDown?.value ?: false
+    val isNavBarHidden = (scrollState?.isScrollingDown?.value ?: false) || (scrollState?.isNavBarEnabled?.value == false)
     val navBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + if (isNavBarHidden) 0.dp else 112.dp
 
     var jsonUrls by remember { mutableStateOf(loadJsonUrls(context)) }

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/ModuleRepo.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/ModuleRepo.kt
@@ -138,6 +138,7 @@ fun ModuleRepoScreen(navigator: DestinationsNavigator) {
     val isManager = Natives.isManager
     val ksuVersion = if (isManager) Natives.version else null
     val scrollState = LocalScrollState.current
+    val haptic = androidx.compose.ui.platform.LocalHapticFeedback.current
     val isNavBarHidden = (scrollState?.isScrollingDown?.value ?: false) || (scrollState?.isNavBarEnabled?.value == false)
     val navBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + if (isNavBarHidden) 0.dp else 112.dp
 
@@ -604,6 +605,9 @@ fun ModuleRepoScreen(navigator: DestinationsNavigator) {
                         .padding(paddingValues),
                     isRefreshing = isRefreshing,
                     onRefresh = {
+                        if (scrollState?.isHapticsEnabled?.value == true) {
+                            haptic.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.LongPress)
+                        }
                         scope.launch {
                             moduleState = ModuleRepoState.Loading
                             loadModules()

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Settings.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Settings.kt
@@ -86,7 +86,7 @@ fun SettingScreen(navigator: DestinationsNavigator) {
     val prefs = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
 
     val scrollState = LocalScrollState.current
-    val isNavBarHidden = scrollState?.isScrollingDown?.value ?: false
+    val isNavBarHidden = (scrollState?.isScrollingDown?.value ?: false) || (scrollState?.isNavBarEnabled?.value == false)
     val navBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + if (isNavBarHidden) 0.dp else 112.dp
 
     val bottomBarScrollState = LocalScrollState.current

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Settings.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Settings.kt
@@ -4,10 +4,16 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.system.OsConstants
+import androidx.compose.material.icons.filled.RadioButtonChecked
+import androidx.compose.material.icons.filled.RadioButtonUnchecked
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.ui.semantics.Role
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.background
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -513,6 +519,89 @@ private fun AppSettingsCard(
                 prefs.edit { putBoolean("check_update", it) }
                 checkUpdate = it
             }
+
+            var requireBiometric by rememberSaveable {
+                mutableStateOf(prefs.getBoolean("enable_biometric_lock", false))
+            }
+            var appLockTimeout by rememberSaveable {
+                mutableStateOf(prefs.getLong("app_lock_timeout", 60000L))
+            }
+            var showTimeoutMenu by remember { mutableStateOf(false) }
+
+            val timeoutOptions = remember {
+                listOf(
+                    0L to R.string.settings_app_lock_timeout_immediate,
+                    60000L to R.string.settings_app_lock_timeout_1m,
+                    300000L to R.string.settings_app_lock_timeout_5m
+                )
+            }
+
+            val timeoutLabelRes = timeoutOptions.find { it.first == appLockTimeout }?.second
+                ?: R.string.settings_app_lock_timeout_1m
+            val timeoutLabel = stringResource(timeoutLabelRes)
+
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(8.dp))
+                    .toggleable(
+                        value = requireBiometric,
+                        role = Role.Switch,
+                        onValueChange = { newValue ->
+                            requireBiometric = newValue
+                            prefs.edit { putBoolean("enable_biometric_lock", newValue) }
+                        }
+                    ),
+                    colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                    leadingContent = { Icon(Icons.Filled.Lock, null) },
+                    headlineContent = { Text(stringResource(R.string.settings_app_lock)) },
+                    supportingContent = {
+                        Column(modifier = Modifier.animateContentSize()) {
+                            Text(stringResource(R.string.settings_app_lock_summary))
+                            if (requireBiometric) {
+                                Box {
+                                    Text(
+                                        text = "${stringResource(R.string.settings_app_lock_timeout)}: $timeoutLabel",
+                                        color = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier
+                                            .padding(top = 4.dp)
+                                            .clickable { showTimeoutMenu = true }
+                                            .padding(vertical = 4.dp)
+                                    )
+                                    DropdownMenu(
+                                        expanded = showTimeoutMenu,
+                                        onDismissRequest = { showTimeoutMenu = false }
+                                    ) {
+                                        timeoutOptions.forEach { (time, stringRes) ->
+                                            DropdownMenuItem(
+                                                text = { Text(stringResource(stringRes)) },
+                                                trailingIcon = {
+                                                    Icon(
+                                                        imageVector = if (appLockTimeout == time) Icons.Filled.RadioButtonChecked else Icons.Filled.RadioButtonUnchecked,
+                                                        contentDescription = null,
+                                                        tint = if (appLockTimeout == time) androidx.compose.material3.MaterialTheme.colorScheme.primary else androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant
+                                                    )
+                                                },
+                                                onClick = {
+                                                    appLockTimeout = time
+                                                    prefs.edit { putLong("app_lock_timeout", time) }
+                                                    showTimeoutMenu = false
+                                                }
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    trailingContent = {
+                        Switch(
+                            checked = requireBiometric,
+                            onCheckedChange = null // Handled by toggleable
+                        )
+                    }
+                )
+
 
             ListItem(
                 modifier = Modifier

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/SuLog.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/SuLog.kt
@@ -507,9 +507,17 @@ fun SulogScreen(navigator: DestinationsNavigator) {
         visibleEntries = uiState.visibleEntries,
         errorMessage = uiState.errorMessage,
     )
+    val scrollStateOuter = LocalScrollState.current
+    val hapticOuter = androidx.compose.ui.platform.LocalHapticFeedback.current
+
     val actions = SulogActions(
         onBack = dropUnlessResumed { navigator.popBackStack() },
-        onRefresh = { viewModel.refreshLatest(refreshing = true) },
+        onRefresh = {
+            if (scrollStateOuter?.isHapticsEnabled?.value == true) {
+                hapticOuter.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.LongPress)
+            }
+            viewModel.refreshLatest(refreshing = true)
+        },
         onEnableSulog = viewModel::enableSulog,
         onCleanFile = viewModel::cleanFile,
         onSearchTextChange = viewModel::setSearchText,

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/SuLog.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/SuLog.kt
@@ -185,7 +185,7 @@ fun SuLogScreen(
                         .fillMaxSize()
                 ) {
                     val scrollState = LocalScrollState.current
-                    val isNavBarHidden = scrollState?.isScrollingDown?.value ?: false
+                    val isNavBarHidden = (scrollState?.isScrollingDown?.value ?: false) || (scrollState?.isNavBarEnabled?.value == false)
                     val navBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + if (isNavBarHidden) 0.dp else 112.dp
 
                     LazyColumn(

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/SuperUser.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/SuperUser.kt
@@ -137,9 +137,15 @@ fun SuperUserScreen(navigator: DestinationsNavigator) {
         },
         contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
     ) { innerPadding ->
+        val scrollStateOuter = LocalScrollState.current
+        val hapticOuter = androidx.compose.ui.platform.LocalHapticFeedback.current
+
         PullToRefreshBox(
             modifier = Modifier.padding(innerPadding),
             onRefresh = {
+                if (scrollStateOuter?.isHapticsEnabled?.value == true) {
+                    hapticOuter.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.LongPress)
+                }
                 scope.launch { viewModel.fetchAppList() }
             },
             isRefreshing = viewModel.isRefreshing

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/SuperUser.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/SuperUser.kt
@@ -145,7 +145,7 @@ fun SuperUserScreen(navigator: DestinationsNavigator) {
             isRefreshing = viewModel.isRefreshing
         ) {
             val scrollState = LocalScrollState.current
-            val isNavBarHidden = scrollState?.isScrollingDown?.value ?: false
+            val isNavBarHidden = (scrollState?.isScrollingDown?.value ?: false) || (scrollState?.isNavBarEnabled?.value == false)
             val navBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + if (isNavBarHidden) 0.dp else 112.dp
 
             LazyColumn(

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Template.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Template.kt
@@ -86,6 +86,9 @@ fun AppProfileTemplateScreen(
 
     val listState = rememberLazyListState()
 
+    val scrollStateOuter = LocalScrollState.current
+    val hapticOuter = androidx.compose.ui.platform.LocalHapticFeedback.current
+
     Scaffold(
         topBar = {
             val clipboard = LocalClipboard.current
@@ -147,6 +150,9 @@ fun AppProfileTemplateScreen(
             modifier = Modifier.padding(innerPadding),
             isRefreshing = viewModel.isRefreshing,
             onRefresh = {
+                if (scrollStateOuter?.isHapticsEnabled?.value == true) {
+                    hapticOuter.performHapticFeedback(androidx.compose.ui.hapticfeedback.HapticFeedbackType.LongPress)
+                }
                 scope.launch { viewModel.fetchTemplates(true) }
             }
         ) {

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Template.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/Template.kt
@@ -151,7 +151,7 @@ fun AppProfileTemplateScreen(
             }
         ) {
             val scrollState = LocalScrollState.current
-            val isNavBarHidden = scrollState?.isScrollingDown?.value ?: false
+            val isNavBarHidden = (scrollState?.isScrollingDown?.value ?: false) || (scrollState?.isNavBarEnabled?.value == false)
             val navBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + if (isNavBarHidden) 0.dp else 112.dp
 
             LazyColumn(

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/TemplateEditor.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/screen/TemplateEditor.kt
@@ -76,7 +76,7 @@ fun TemplateEditorScreen(
     } else null
 
     val scrollState = LocalScrollState.current
-    val isNavBarHidden = scrollState?.isScrollingDown?.value ?: false
+    val isNavBarHidden = (scrollState?.isScrollingDown?.value ?: false) || (scrollState?.isNavBarEnabled?.value == false)
     val navBarPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + if (isNavBarHidden) 0.dp else 112.dp
 
     BackHandler {

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/util/AppLockManager.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/util/AppLockManager.kt
@@ -1,0 +1,44 @@
+package com.rifsxd.ksunext.ui.util
+
+import android.os.SystemClock
+
+object AppLockManager {
+    var activeActivities = 0
+    var lastBackgroundTime = 0L
+    var isUnlocked = false
+    var wasUnlockedBeforeBackground = false
+
+    fun onActivityStart() {
+        activeActivities++
+    }
+
+    fun onActivityStop() {
+        activeActivities--
+        if (activeActivities == 0) {
+            lastBackgroundTime = SystemClock.elapsedRealtime()
+            wasUnlockedBeforeBackground = isUnlocked
+            isUnlocked = false
+        }
+    }
+
+    fun shouldPrompt(timeout: Long): Boolean {
+        if (!isUnlocked) {
+            if (lastBackgroundTime == 0L) return true
+            if (!wasUnlockedBeforeBackground) return true
+
+            val timeInBackground = SystemClock.elapsedRealtime() - lastBackgroundTime
+            if (timeInBackground < timeout) {
+                isUnlocked = true
+                return false
+            }
+            return true
+        }
+        return false
+    }
+
+    fun unlock() {
+        isUnlocked = true
+        wasUnlockedBeforeBackground = true
+        lastBackgroundTime = 0L
+    }
+}

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/util/BiometricAuth.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/util/BiometricAuth.kt
@@ -1,0 +1,35 @@
+package com.rifsxd.ksunext.ui.util
+
+import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
+import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
+import androidx.biometric.BiometricPrompt
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+
+class BiometricAuthenticator(private val activity: FragmentActivity) {
+
+    fun authenticate(title: String, subtitle: String, onSuccess: () -> Unit, onError: (String) -> Unit) {
+        val executor = ContextCompat.getMainExecutor(activity)
+
+        val biometricPrompt = BiometricPrompt(activity, executor,
+            object : BiometricPrompt.AuthenticationCallback() {
+                override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                    super.onAuthenticationSucceeded(result)
+                    onSuccess()
+                }
+
+                override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+                    super.onAuthenticationError(errorCode, errString)
+                    onError(errString.toString())
+                }
+            })
+
+        val promptInfo = BiometricPrompt.PromptInfo.Builder()
+            .setTitle(title)
+            .setSubtitle(subtitle)
+            .setAllowedAuthenticators(BIOMETRIC_STRONG or DEVICE_CREDENTIAL)
+            .build()
+
+        biometricPrompt.authenticate(promptInfo)
+    }
+}

--- a/manager/app/src/main/java/com/rifsxd/ksunext/ui/webui/WebUIActivity.kt
+++ b/manager/app/src/main/java/com/rifsxd/ksunext/ui/webui/WebUIActivity.kt
@@ -38,8 +38,12 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
+import androidx.fragment.app.FragmentActivity
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.fillMaxSize
+
 @SuppressLint("SetJavaScriptEnabled")
-class WebUIActivity : ComponentActivity() {
+class WebUIActivity : FragmentActivity() {
 
     private lateinit var webviewInterface: WebViewInterface
     private val rootShell by lazy { createRootShell(true) }
@@ -59,6 +63,11 @@ class WebUIActivity : ComponentActivity() {
 
     private var insetsContinuation: CancellableContinuation<Unit>? = null
     private var isInsetsEnabled = false
+
+
+    private var appLockState = false
+    private var isPromptShowing = false
+    private lateinit var lockOverlay: android.view.View
 
     fun erudaConsole(context: android.content.Context): String {
         return context.assets.open("eruda.min.js").bufferedReader().use { it.readText() }
@@ -140,6 +149,14 @@ class WebUIActivity : ComponentActivity() {
         val prefs = getSharedPreferences("settings", MODE_PRIVATE)
         val developerOptionsEnabled = prefs.getBoolean("enable_developer_options", false)
         val enableWebDebugging = prefs.getBoolean("enable_web_debugging", false)
+
+        if (savedInstanceState != null) {
+            appLockState = savedInstanceState.getBoolean("appLockState", false)
+
+        } else {
+            val isInternal = intent?.getBooleanExtra("is_internal_transition", false) ?: false
+            appLockState = if (isInternal) false else prefs.getBoolean("enable_biometric_lock", false)
+        }
 
         WebView.setWebContentsDebuggingEnabled(developerOptionsEnabled && enableWebDebugging)
 
@@ -306,6 +323,31 @@ class WebUIActivity : ComponentActivity() {
         setupWebUIBackHandler()
         
         container.addView(webView)
+
+        val prefsInit = getSharedPreferences("settings", MODE_PRIVATE)
+        val requireBiometric = prefsInit.getBoolean("enable_biometric_lock", false)
+
+        if (requireBiometric || appLockState) {
+            val amoledMode = prefsInit.getBoolean("enable_amoled", false)
+            val isDarkTheme = (resources.configuration.uiMode and android.content.res.Configuration.UI_MODE_NIGHT_MASK) == android.content.res.Configuration.UI_MODE_NIGHT_YES
+
+            lockOverlay = android.view.View(this).apply {
+                setBackgroundColor(
+                    if (amoledMode && isDarkTheme) {
+                        android.graphics.Color.BLACK
+                    } else {
+                        val typedValue = android.util.TypedValue()
+                        theme.resolveAttribute(android.R.attr.colorBackground, typedValue, true)
+                        typedValue.data
+                    }
+                )
+                visibility = if (appLockState) android.view.View.VISIBLE else android.view.View.GONE
+                isClickable = true
+                isFocusable = true
+            }
+            container.addView(lockOverlay)
+        }
+
         setContentView(container)
 
         // coroutine-safe inset wait
@@ -410,6 +452,63 @@ class WebUIActivity : ComponentActivity() {
                 ViewCompat.requestApplyInsets(container)
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (appLockState) {
+            val prefs = getSharedPreferences("settings", MODE_PRIVATE)
+            val timeout = prefs.getLong("app_lock_timeout", 60000L)
+
+            if (!com.rifsxd.ksunext.ui.util.AppLockManager.shouldPrompt(timeout)) {
+                appLockState = false
+                if (::lockOverlay.isInitialized) lockOverlay.visibility = android.view.View.GONE
+                return
+            }
+
+            if (!isPromptShowing) {
+                isPromptShowing = true
+                lockOverlay.visibility = android.view.View.VISIBLE
+                com.rifsxd.ksunext.ui.util.BiometricAuthenticator(this)
+                    .authenticate(
+                        title = getString(com.rifsxd.ksunext.R.string.app_name),
+                        subtitle = getString(com.rifsxd.ksunext.R.string.biometric_prompt_subtitle),
+                        onSuccess = {
+                            isPromptShowing = false
+                            appLockState = false
+                            if (::lockOverlay.isInitialized) lockOverlay.visibility = android.view.View.GONE
+                            com.rifsxd.ksunext.ui.util.AppLockManager.unlock()
+                        },
+                        onError = {
+                            isPromptShowing = false
+                            Toast.makeText(this, "Auth failed: $it", Toast.LENGTH_SHORT).show()
+                            finish()
+                        }
+                    )
+            }
+        } else {
+            if (::lockOverlay.isInitialized) lockOverlay.visibility = android.view.View.GONE
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        com.rifsxd.ksunext.ui.util.AppLockManager.onActivityStart()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        com.rifsxd.ksunext.ui.util.AppLockManager.onActivityStop()
+        val prefs = getSharedPreferences("settings", MODE_PRIVATE)
+        if (prefs.getBoolean("enable_biometric_lock", false)) {
+            appLockState = true
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean("appLockState", appLockState)
+
     }
 
     override fun onDestroy() {

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -147,6 +147,8 @@
     <string name="restart_app">Restart</string>
     <string name="settings_amoled_mode">AMOLED mode</string>
     <string name="settings_amoled_mode_summary">Enable a pure black theme useful for AMOLED screens to reduce eye strain and save battery.</string>
+    <string name="settings_navbar">Navigation bar</string>
+    <string name="settings_navbar_summary">Enable the bottom navigation bar.</string>
     <string name="restart_required">Restart required</string>
     <string name="restart_app_message">The app needs to restart for this change to take effect.</string>
     <string name="failed_to_update_sepolicy">Failed to update SELinux rules for %s</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -149,6 +149,8 @@
     <string name="settings_amoled_mode_summary">Enable a pure black theme useful for AMOLED screens to reduce eye strain and save battery.</string>
     <string name="settings_navbar">Navigation bar</string>
     <string name="settings_navbar_summary">Enable the bottom navigation bar.</string>
+    <string name="settings_haptics">Haptic feedback</string>
+    <string name="settings_haptics_summary">Enable haptic feedback on gestures.</string>
     <string name="restart_required">Restart required</string>
     <string name="restart_app_message">The app needs to restart for this change to take effect.</string>
     <string name="failed_to_update_sepolicy">Failed to update SELinux rules for %s</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -307,4 +307,11 @@
     <string name="sulog_uid">UID %1$s</string>
     <string name="sulog_status_success">Success</string>
     <string name="sulog_status_exit">Exit %1$d</string>
+    <string name="settings_app_lock">App lock</string>
+    <string name="settings_app_lock_summary">Require authentication when opening the app.</string>
+    <string name="settings_app_lock_timeout">Grace period</string>
+    <string name="settings_app_lock_timeout_immediate">Immediate</string>
+    <string name="settings_app_lock_timeout_1m">1 minute</string>
+    <string name="settings_app_lock_timeout_5m">5 minutes</string>
+    <string name="biometric_prompt_subtitle">Authenticate to access manager</string>
 </resources>

--- a/manager/build.gradle.kts
+++ b/manager/build.gradle.kts
@@ -37,25 +37,78 @@ val androidTargetCompatibility = JavaVersion.VERSION_21
 val managerVersionCode by extra(getVersionCode())
 val managerVersionName by extra(getVersionName())
 
-fun getGitCommitCount(): Int {
-    val process = Runtime.getRuntime().exec(arrayOf("git", "rev-list", "--count", "HEAD"))
-    return process.inputStream.bufferedReader().use { it.readText().trim().toInt() }
+// Helper for shell cmds.
+fun runCommand(vararg command: String): String =
+    ProcessBuilder(*command)
+        .redirectErrorStream(true)
+        .start()
+        .inputStream.bufferedReader()
+        .use { it.readText().trim() }
+
+// Get cur. branch; strip suffixes (e.g. dev-susfs -> dev)
+fun getCurrentBranch(): String {
+    val branchRaw = runCommand("git", "rev-parse", "--abbrev-ref", "HEAD")
+    return if (branchRaw.isEmpty() || branchRaw == "HEAD") "dev" else branchRaw.split("-")[0]
 }
 
-fun getGitDescribe(): String {
-    val process = Runtime.getRuntime().exec(arrayOf("git", "describe", "--tags", "--always"))
-    return process.inputStream.bufferedReader().use { it.readText().trim() }
+// Get upstream: commit count, hash, describe number
+fun getUpstreamDescribe(): Triple<Int, String, Int> {
+    val branch = getCurrentBranch()
+
+    // Find common ancestor with origin/$branch, or origin/main as fallback, to exclude local delta
+    var baseCommit = runCommand("git", "merge-base", "HEAD", "refs/remotes/origin/$branch")
+    if (baseCommit.contains("fatal") || baseCommit.isEmpty()) {
+        baseCommit = runCommand("git", "merge-base", "HEAD", "refs/remotes/origin/main")
+    }
+    if (baseCommit.contains("fatal") || baseCommit.isEmpty()) {
+        baseCommit = "HEAD"
+    }
+
+    val describe = runCommand("git", "describe", "--tags", "--long", "--abbrev=8", baseCommit)
+    val parts = describe.split("-")
+
+    // Fallback if no tags
+    if (parts.size < 3) {
+        val commitCount = runCommand("git", "rev-list", "--count", baseCommit).let { if (it.isEmpty()) 0 else it.toInt() }
+        val hash = runCommand("git", "rev-parse", "--short=8", baseCommit)
+        return Triple(commitCount, hash, 0)
+    }
+
+    val num = parts[parts.size - 2].toInt()
+    val hash = parts.last().removePrefix("g")
+
+    val commitCount = runCommand("git", "rev-list", "--count", baseCommit).let { if (it.isEmpty()) 0 else it.toInt() }
+
+    return Triple(commitCount, hash, num)
 }
 
+// Version code calc.
 fun getVersionCode(): Int {
-    val commitCount = getGitCommitCount()
+    val (commitCount, _, _) = getUpstreamDescribe()
     val major = 1
     return major * 30000 + commitCount
 }
 
+// Version name (upstream tag, describe number, hash)
 fun getVersionName(): String {
-    return getGitDescribe()
+    val (commitCount, hash, num) = getUpstreamDescribe()
+    val branch = getCurrentBranch()
+
+    var baseCommit = runCommand("git", "merge-base", "HEAD", "refs/remotes/origin/$branch")
+    if (baseCommit.contains("fatal") || baseCommit.isEmpty()) {
+        baseCommit = runCommand("git", "merge-base", "HEAD", "refs/remotes/origin/main")
+    }
+    if (baseCommit.contains("fatal") || baseCommit.isEmpty()) {
+        baseCommit = "HEAD"
+    }
+
+    val tag = runCommand("git", "describe", "--tags", "--abbrev=0", baseCommit).let { if (it.isEmpty() || it.contains("fatal")) "v0.0.0" else it }
+    return "$tag-$num-g$hash"
 }
+
+// Root project version info. assignment (extras)
+rootProject.extra.set("managerVersionCode", getVersionCode())
+rootProject.extra.set("managerVersionName", getVersionName())
 
 subprojects {
     plugins.withType(AndroidBasePlugin::class.java) {

--- a/userspace/ksud/build.rs
+++ b/userspace/ksud/build.rs
@@ -9,9 +9,29 @@ const BOOTSTRAP_SOURCE: &str = "src/lkm_image_bootstrap.S";
 const BOOTSTRAP_OBJECT: &str = "lkm_image_bootstrap.o";
 const PREPARED_BOOTSTRAP_OBJECT: &str = ".lkm_image_bootstrap.o";
 
+fn get_base_commit() -> String {
+    let branch = Command::new("git").args(["rev-parse", "--abbrev-ref", "HEAD"]).output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string()).unwrap_or_else(|_| "dev".into());
+    let b = branch.split('-').next().unwrap_or("dev");
+    let b = if b.is_empty() || b == "HEAD" { "dev" } else { b };
+
+    let mut base = Command::new("git").args(["merge-base", "HEAD", &format!("refs/remotes/origin/{}", b)]).output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string()).unwrap_or_default();
+    if base.is_empty() || base.contains("fatal") {
+        base = Command::new("git").args(["merge-base", "HEAD", "refs/remotes/origin/main"]).output()
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string()).unwrap_or_default();
+    }
+    if base.is_empty() || base.contains("fatal") {
+        "HEAD".to_string()
+    } else {
+        base
+    }
+}
+
 fn get_git_version() -> Result<(u32, String), std::io::Error> {
+    let base_commit = get_base_commit();
     let output = Command::new("git")
-        .args(["rev-list", "--count", "HEAD"])
+        .args(["rev-list", "--count", &base_commit])
         .output()?;
 
     let output = output.stdout;
@@ -24,7 +44,7 @@ fn get_git_version() -> Result<(u32, String), std::io::Error> {
 
     let version_name = String::from_utf8(
         Command::new("git")
-            .args(["describe", "--tags", "--always"])
+            .args(["describe", "--tags", "--always", &base_commit])
             .output()?
             .stdout,
     )

--- a/userspace/ksud/src/cli.rs
+++ b/userspace/ksud/src/cli.rs
@@ -517,7 +517,7 @@ pub fn run() -> Result<()> {
     log::info!("command: {:?}", cli.command);
 
     let result = match cli.command {
-        Commands::PostFsData => init_event::on_post_data_fs(),
+        Commands::PostFsData => init_event::on_post_data_fs(false),
         Commands::BootCompleted => {
             init_event::on_boot_completed();
             Ok(())

--- a/userspace/ksud/src/init_event.rs
+++ b/userspace/ksud/src/init_event.rs
@@ -282,6 +282,16 @@ pub fn soft_reboot() -> Result<()> {
     }
     on_boot_completed();
 
+    // Workaround for wireless debugging dropping on soft reboot
+    if let Ok(out) = Command::new("settings").args(["get", "global", "adb_wifi_enabled"]).output() {
+        if String::from_utf8_lossy(&out.stdout).trim() == "1" {
+            info!("Kicking wireless debugging...");
+            let _ = Command::new("settings").args(["put", "global", "adb_wifi_enabled", "0"]).status();
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            let _ = Command::new("settings").args(["put", "global", "adb_wifi_enabled", "1"]).status();
+        }
+    }
+
     unsafe {
         _exit(0);
     }

--- a/userspace/ksud/src/init_event.rs
+++ b/userspace/ksud/src/init_event.rs
@@ -13,7 +13,7 @@ use rustix::process::chdir;
 use std::path::Path;
 use std::process::Command;
 
-pub fn on_post_data_fs() -> Result<()> {
+pub fn on_post_data_fs(is_soft_reboot: bool) -> Result<()> {
     if let Err(e) = ksucalls::ensure_uapi_version_matched() {
         error!("{e:#}, skip on_post_fs_data");
         return Ok(());
@@ -44,7 +44,7 @@ pub fn on_post_data_fs() -> Result<()> {
         // we should still ensure module directory exists in safe mode
         // because we may need to operate the module dir in safe mode
         warn!("safe mode, skip common post-fs-data.d scripts");
-    } else {
+    } else if !is_soft_reboot {
         // Then exec common post-fs-data scripts
         if let Err(e) = crate::module::exec_common_scripts("post-fs-data.d", true) {
             warn!("exec common post-fs-data scripts failed: {e}");
@@ -269,7 +269,7 @@ pub fn soft_reboot() -> Result<()> {
         warn!("stop exited with status: {status}");
     }
     info!("post-fs-data");
-    on_post_data_fs()?;
+    on_post_data_fs(true)?;
     info!("start");
     let status = Command::new("start").status().context("start failed")?;
     if !status.success() {


### PR DESCRIPTION
## Description

Fixes an issue where the device enters a boot loop when attempting to boot into Recovery Mode.

### Root Cause
In Recovery Mode, the standard Android boot sequence (`/system/bin/init second_stage` -> zygote -> `on_post_fs_data`) does not occur. As a result:
- `apply_kernelsu_rules()` and `setup_ksu_cred()` are never executed.
- Static keys for `init.rc` reading/fstat hooks and input event hooks remain permanently enabled.
- Hooks on `execveat` continue intercepting all processes spawned by recovery init, causing deadlocks or unexpected behavior during recovery initialization.

### Solution
- Added detection of Recovery Mode from the kernel command line (`saved_command_line` checking for `androidboot.force_normal_boot=0`, `androidboot.mode=recovery`, or `bootmode=recovery`).
- When Recovery Mode is detected during `kernelsu_init()`:
  - Sets global flag `ksu_is_recovery = true`.
  - Disables static branches for `init.rc` hooks and input hooks.
  - Aborts `ksud` execveat, sys_read, and vfs_fstat hooks early.
  - Automatically enables safe mode.

### Testing
Tested and verified on:
- Device: ASUS ROG Phone 6 (AI2201)
- OS: Android 13
- Kernel: GKI 5.10 with KernelSU-Next + SUSFS v2.2.0

With this fix, the device boots normally into Recovery Mode without reboot loops.